### PR TITLE
chore: UI polish and agent rules update

### DIFF
--- a/.augment/rules/01-go-conventions.md
+++ b/.augment/rules/01-go-conventions.md
@@ -66,20 +66,14 @@ func (bs *BackgroundSession) GetNextSeq() int64 {
 
 ## Deadlock Prevention
 
-```go
-// WRONG: Calling method that acquires lock while holding lock
-func (r *Recorder) Start() error {
-    r.mu.Lock()
-    defer r.mu.Unlock()
-    r.recordEvent(...)  // recordEvent also locks r.mu!
-}
+**Rule**: Never call a method that acquires `r.mu` while already holding `r.mu`.
 
-// RIGHT: Call store directly or release lock first
-func (r *Recorder) Start() error {
-    r.mu.Lock()
-    defer r.mu.Unlock()
-    r.store.AppendEvent(...)  // Store has its own lock
-}
+```go
+// WRONG — recordEvent also locks r.mu → deadlock
+r.mu.Lock(); defer r.mu.Unlock(); r.recordEvent(...)
+
+// RIGHT — call store directly (has its own lock)
+r.mu.Lock(); defer r.mu.Unlock(); r.store.AppendEvent(...)
 ```
 
 ## Explicit Lock Management in Retry Loops
@@ -88,13 +82,23 @@ func (r *Recorder) Start() error {
 
 **Rule**: In retry loops that release and reacquire a lock, use **explicit `mu.Unlock()` on every exit path** instead of `defer`. Extract goroutine+select lock-acquisition into a helper (e.g. `acquireAuxLock`) to keep all retry paths clean. See `internal/web/acp_process_manager.go` for a real example.
 
-## PID Checking
+### TryLock: Release Before Post-Processing
+
+`defer mu.Unlock()` holds the lock through ALL post-response work. If a response is sent mid-function and the caller immediately sends a follow-up using `TryLock`, the follow-up is silently dropped.
+
+**Rule**: Use explicit `mu.Unlock()` after the core response send; do slow post-processing after unlocking.
 
 ```go
-func isPIDRunning(pid int) bool {
-    process, _ := os.FindProcess(pid)
-    return process.Signal(syscall.Signal(0)) == nil
-}
+// BAD: defer holds lock through slow post-processing; TryLock from follow-up fails
+c.loadEventsMu.Lock()
+defer c.loadEventsMu.Unlock()
+c.handleLoadEvents(req)   // sends response; client immediately sends follow-up → TryLock fails
+
+// GOOD: explicit unlock after response, before post-processing
+c.loadEventsMu.Lock()
+result := c.handleLoadEvents(req)
+c.loadEventsMu.Unlock()         // release here
+c.postLoadProcessing(result)    // follow-up can now acquire lock
 ```
 
 ## Structured Logging
@@ -125,21 +129,7 @@ if strings.Contains(err.Error(), "session not started") {
 }
 ```
 
-## JSON Marshaling: Nil vs Empty Slices
+## JSON Marshaling
 
-`json.Marshal` encodes a nil slice as `null` and an empty slice as `[]`. ACP and other APIs that validate with JSON Schema will reject `null` where an array is required.
-
-```go
-// BAD — marshals as "mcpServers": null
-type SessionParams struct {
-    MCPServers []MCPServer `json:"mcpServers"`
-}
-params := SessionParams{} // MCPServers is nil
-
-// GOOD — marshals as "mcpServers": []
-params := SessionParams{
-    MCPServers: []MCPServer{}, // or: make([]MCPServer, 0)
-}
-```
-
-**Rule:** Always initialize slice fields that appear in JSON-serialized API request structs, even when empty. Do not rely on zero values for outbound JSON payloads. Mark intentional empty-slice inits with `// Must be empty array, not nil — ACP validates this`.
+- **Nil vs empty slices**: `json.Marshal` encodes nil as `null`, empty as `[]`. ACP rejects `null` where array is required. Always initialize: `MCPServers: []MCPServer{}`. Mark with `// Must be empty array, not nil — ACP validates this`.
+- **`omitempty` on bool**: Never use `omitempty` on `bool` fields where `false` is meaningful — Go omits `false` as zero value. Example: `PeriodicEnabled bool` must NOT have `omitempty`.

--- a/.augment/rules/22-web-frontend-websocket.md
+++ b/.augment/rules/22-web-frontend-websocket.md
@@ -240,6 +240,26 @@ case "events_loaded": {
 
 All streaming messages include `max_seq`. Call `checkAndFillGap` in all message handlers to detect missed events without waiting for keepalive.
 
+## `connected` Handler: Preserve Existing Values with `??`
+
+The `connected` message is sent on every (re)connect, but may omit fields that weren't yet available (e.g., before `acp_started`). Using `||` overwrites existing values with `[]`/`false`/etc., causing UI flicker. Always use `??` to preserve existing session info:
+
+```javascript
+// BAD: wipes existing config_options when server omits the field on reconnect
+case "connected":
+    updateSession(sessionId, { info: {
+        config_options: msg.data.config_options || [],   // [] overwrites existing!
+    }});
+
+// GOOD: preserve existing value when server omits the field
+case "connected":
+    updateSession(sessionId, { info: {
+        config_options: msg.data.config_options ?? session.info?.config_options ?? [],
+    }});
+```
+
+**Rule:** In the `connected` handler, use `??` (nullish coalescing) for all optional fields, falling back to the existing `session.info` value before the default.
+
 ## Timeout Anti-Pattern
 
 ```javascript

--- a/.augment/rules/25-web-frontend-components.md
+++ b/.augment/rules/25-web-frontend-components.md
@@ -53,20 +53,9 @@ All components use Preact/HTM with window globals: `const { useState, useEffect,
 
 ### Layout: "Contained Composition" (GitHub-style)
 
-Single bordered container with textarea at top and an integrated bottom toolbar row with three sections:
+Single bordered container: textarea (no own border) + bottom toolbar with left/center/right sections.
 
-```
-┌─────────────────────────────────────────────┐
-│ Textarea (no own border, full-width)        │
-│ "Ask anything..."                           │
-│ ┌─────────────────────────────────────────┐ │
-│ │ 🖼️ 📎 ✨ 💾  │  [model▼]  │  + ≡  ⌃  ▶  │ │
-│ │  (left)        │  (center)  │  (right)   │ │
-│ └─────────────────────────────────────────┘ │
-└─────────────────────────────────────────────┘
-```
-
-- **Outer container**: provides the border and rounded corners — textarea has no own border
+- **Outer container**: provides border and rounded corners — textarea has no own border
 - **Bottom toolbar left**: attach-image, attach-file, improve-prompt, save-prompt
 - **Bottom toolbar center**: model selector (only shown when `configOptions` contains a `type === "select"` option)
 - **Bottom toolbar right**: queue-add, queue-toggle, **prompts-toggle**, send/stop/lock
@@ -98,22 +87,6 @@ const selectConfigOptions = useMemo(() => {
 | `Shift+Enter`    | New line     |
 | `Cmd/Ctrl+Enter` | Add to queue |
 
-### Config Selectors (configOptions)
-
-ChatInput accepts `configOptions` (array) and `onSetConfigOption` (callback) props from `app.js`. The center bar shows **all** `type === "select"` options (e.g. "Mode" and "Model"):
-
-```javascript
-const selectConfigOptions = useMemo(() => {
-  return configOptions?.filter(o => o.type === "select" && o.options?.length > 0) || [];
-}, [configOptions]);
-// Renders one <select> per option; hidden when array is empty
-// Each: <select disabled=${isStreaming} onInput=${e => onSetConfigOption?.(opt.id, e.target.value)}>
-```
-
-- Disabled while streaming; hidden when no select-type config options exist
-- CSS classes: `chat-input-model-selector` (container) / `chat-input-model-select` (each `<select>`)
-- **Anti-pattern**: Do NOT use `find()` to show only the first option — use `filter()` to show all
-
 ## QueueDropdown
 
 Resizable via `useResizeHandle` (initialHeight: `getQueueDropdownHeight()`, min: 100, max: 500). Auto-closes after 5s inactivity; paused on hover and drag.
@@ -129,17 +102,7 @@ Naming: `[Name]Icon` (e.g., `TrashIcon`, `GripIcon`, `QueueIcon`, `TagIcon`). Al
 ### Changes Tab
 Fetches `GET /api/sessions/{id}/changes` when active. Displays branch name, file count, refresh button, and file list with color-coded status badges (A=green, M=amber, D=red, R=blue, ?=gray) and `+N/-N` stats. Clicking a file opens the viewer in diff mode (`view=diff` param).
 
-### Animation & DOM
-
-Uses `isClosing`/`shouldRender` state pair for slide-in/slide-out (150ms). CSS classes `properties-panel`/`properties-backdrop` with `closing` variant. Fixed right-side overlay: backdrop on left, panel on right.
-
-### Icon Convention
-
-Use `TagIcon` for user data / metadata panels (defined in `Icons.js`).
-
-## Header Status Dot
-
-The connection status dot in the header is a **plain indicator only** (not a clickable button). Style matches the status dots in the session list.
+Animation: `isClosing`/`shouldRender` pair for slide-in/slide-out (150ms). Use `TagIcon` for metadata panels.
 
 ## useToast Hook (Unified Notification System)
 
@@ -148,15 +111,10 @@ The connection status dot in the header is a **plain indicator only** (not a cli
 ```javascript
 const { showToast, dismissToast, toasts } = useToast();
 showToast({ message: "Saved", style: "success" }); // auto-dismiss 5s
-showToast({ message: "Failed", style: "error" });   // auto-dismiss 10s
-showToast({ message: "Pinned", sticky: true });      // no auto-dismiss
+showToast({ message: "Pinned", sticky: true });     // no auto-dismiss
 ```
 
-Severity durations: info/success=5s, warning/error=10s. Max 5 simultaneous (oldest evicted). Render via `<ToastContainer toasts=${toasts} onDismiss=${dismissToast} />`.
-
-**Style selection**: `error` (red) = actual errors only. Use `info` for neutral events. **Anti-pattern**: never use `error` for non-error notifications — red implies urgency.
-
-**v2 theme CSS anti-pattern**: `styles-v2.css` globally remaps `.text-white` → near-black and `bg-blue-600` → red. Components with semantic colors (info=blue, not red) need scoped overrides using their wrapper class. Toast fixes use `.v2-theme .toast-enter .bg-*` and `.v2-theme .toast-enter .text-white`. See existing patterns at `styles-v2.css` ~lines 836–910.
+Severity durations: info/success=5s, warning/error=10s. Max 5 simultaneous. Render via `<ToastContainer toasts=${toasts} onDismiss=${dismissToast} />`. Use `error` (red) for actual errors only.
 
 ## useResizeHandle / useSwipeNavigation / New Hooks
 
@@ -164,9 +122,27 @@ Severity durations: info/success=5s, warning/error=10s. Max 5 simultaneous (olde
 - `useSwipeNavigation`: swipe left/right with threshold, edge detection. 500ms window.
 - **New hooks**: `use[Name].js`, export from `hooks/index.js`, use `window.preact` globals, cleanup in useEffect.
 
-## Session List: Parent-Child UI Rules
+## Hooks in Conditionals (Anti-Pattern)
 
-- Children accordion: only one parent's children expanded at a time (accordion mode always on for `parent:*` groups)
-- Group key format: `parent:${session.session_id}` — separate from folder-level keys
-- `sessionFamilyMap` (useMemo) maps session IDs to their family key; used in `handleSelectWithCollapse`
-- **Child restrictions**: cannot be archived, cannot be made periodic — hide/disable those actions in UI
+Preact/React hooks must be called unconditionally. When a hook is needed inside a conditional, extract a dedicated sub-component:
+
+```javascript
+// BAD: useState inside if-block — violates Rules of Hooks
+function Message({ isThought }) {
+  if (isThought) {
+    const [collapsed, setCollapsed] = useState(true);  // ❌
+    return html`...`;
+  }
+}
+
+// GOOD: extract ThoughtBubble so hooks always run at top level
+function ThoughtBubble({ message }) {
+  const [collapsed, setCollapsed] = useState(true);  // ✓ always called
+  return html`...`;
+}
+function Message({ isThought, ...props }) {
+  if (isThought) return html`<${ThoughtBubble} ...${props} />`;
+}
+```
+
+Define extracted components in the **same file** — no new files needed.

--- a/.augment/rules/25-web-frontend-components.md
+++ b/.augment/rules/25-web-frontend-components.md
@@ -58,7 +58,7 @@ Single bordered container: textarea (no own border) + bottom toolbar with left/c
 - **Outer container**: provides border and rounded corners — textarea has no own border
 - **Bottom toolbar left**: attach-image, attach-file, improve-prompt, save-prompt
 - **Bottom toolbar center**: model selector (only shown when `configOptions` contains a `type === "select"` option)
-- **Bottom toolbar right**: queue-add, queue-toggle, **prompts-toggle**, send/stop/lock
+- **Bottom toolbar right**: prompts-toggle, queue-toggle (visible when queue non-empty or dropdown open), enqueue (visible while streaming), send/stop/lock
 - **No floating action-toolbar** — all actions are in the always-visible bottom bar
 
 > **Anti-pattern**: Do NOT use the old "textarea + external button column" layout. The floating toolbar that appeared on focus has been removed.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -4980,10 +4980,6 @@ function App() {
 
   // Queue dropdown handlers
   const handleToggleQueueDropdown = useCallback(() => {
-    console.log(
-      "[DEBUG] handleToggleQueueDropdown called, current showQueueDropdown:",
-      showQueueDropdown,
-    );
     // Cancel any auto-close timer when user manually toggles
     if (queuePanelAutoCloseTimerRef.current) {
       clearTimeout(queuePanelAutoCloseTimerRef.current);
@@ -4993,10 +4989,7 @@ function App() {
       // Opening - fetch latest queue messages
       fetchQueueMessages();
     }
-    setShowQueueDropdown((prev) => {
-      console.log("[DEBUG] setShowQueueDropdown: prev=", prev, "new=", !prev);
-      return !prev;
-    });
+    setShowQueueDropdown((prev) => !prev);
   }, [showQueueDropdown, fetchQueueMessages]);
 
   const handleCloseQueueDropdown = useCallback(() => {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1782,13 +1782,13 @@ function SessionList({
   const getGroupingIcon = () => {
     switch (groupingMode) {
       case "server":
-        return html`<${ServerIcon} className="w-5 h-5" />`;
+        return html`<${ServerIcon} className="w-4 h-4" />`;
       case "folder":
-        return html`<${FolderIcon} className="w-5 h-5" />`;
+        return html`<${FolderIcon} className="w-4 h-4" />`;
       case "workspace":
-        return html`<${LayersIcon} className="w-5 h-5" />`;
+        return html`<${LayersIcon} className="w-4 h-4" />`;
       default:
-        return html`<${ListIcon} className="w-5 h-5" />`;
+        return html`<${ListIcon} className="w-4 h-4" />`;
     }
   };
 
@@ -2864,29 +2864,29 @@ function SessionList({
         class="p-4 border-b border-slate-700 flex items-center justify-between"
       >
         <h2 class="font-semibold text-lg">Conversations</h2>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-0.5">
           <button
             onClick=${handleToggleGrouping}
-            class="p-2 hover:bg-slate-700 rounded-lg transition-colors"
+            class="p-1.5 hover:bg-slate-700 rounded transition-colors"
             title=${getGroupingTooltip()}
           >
             ${getGroupingIcon()}
           </button>
           <button
             onClick=${() => onNewSession(null, null, filterTab)}
-            class="p-2 hover:bg-slate-700 rounded-lg transition-colors"
+            class="p-1.5 hover:bg-slate-700 rounded transition-colors"
             title="New Conversation"
           >
-            <${PlusIcon} className="w-5 h-5" />
+            <${PlusIcon} className="w-4 h-4" />
           </button>
           ${onClose &&
           html`
             <button
               onClick=${onClose}
-              class="p-2 hover:bg-slate-700 rounded-lg transition-colors md:hidden"
+              class="p-1.5 hover:bg-slate-700 rounded transition-colors md:hidden"
               title="Close"
             >
-              <${CloseIcon} className="w-5 h-5" />
+              <${CloseIcon} className="w-4 h-4" />
             </button>
           `}
         </div>
@@ -2963,17 +2963,17 @@ function SessionList({
           <!-- Settings | Workspaces segmented button (disabled with tooltip when using RC file, hidden when fully read-only without RC file) -->
           ${!configReadonly
             ? html`
-                <div class="flex items-center">
+                <div class="flex items-center gap-0.5">
                   <button
                     onClick=${onShowSettings}
-                    class="p-2 hover:bg-slate-700 rounded-lg transition-colors text-gray-400 hover:text-white"
+                    class="p-1.5 hover:bg-slate-700 rounded transition-colors text-gray-400 hover:text-white"
                     title="Settings"
                   >
                     <${SettingsIcon} className="w-4 h-4" />
                   </button>
                   <button
                     onClick=${onShowWorkspaces}
-                    class="p-2 hover:bg-slate-700 rounded-lg transition-colors text-gray-400 hover:text-white"
+                    class="p-1.5 hover:bg-slate-700 rounded transition-colors text-gray-400 hover:text-white"
                     title="Workspaces"
                   >
                     <${FolderIcon} className="w-4 h-4" />

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -2741,26 +2741,13 @@ ${activeUIPrompt.text || ""}</textarea
                 </div>
               `}
 
-              <!-- Right action buttons: queue-add, queue-toggle, prompts-toggle, send/stop/lock -->
+              <!-- Right action buttons: queue-toggle, prompts, enqueue, send/stop/lock -->
               <div class="chat-input-actions-right">
-                <!-- Add to Queue button -->
-                <button
-                  type="button"
-                  onClick=${handleAddToQueueClick}
-                  disabled=${isFullyDisabled || (!text.trim() && !hasPendingAttachments) || isReadOnly || isImproving || periodicEnabled}
-                  class="chat-input-action"
-                  title=${periodicEnabled ? "Queue disabled for periodic sessions" : "Add to queue (⌘/Ctrl+Enter)"}
-                >
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                  </svg>
-                </button>
-
-                <!-- Toggle Queue Panel button -->
+                <!-- Queue toggle button: only shown when queue has items -->
+                ${queueLength > 0 && html`
                 <button
                   type="button"
                   onClick=${() => {
-                    console.log("[DEBUG] Queue toggle button clicked, onToggleQueue=", typeof onToggleQueue);
                     if (!periodicEnabled && onToggleQueue) onToggleQueue();
                   }}
                   disabled=${periodicEnabled}
@@ -2774,8 +2761,9 @@ ${activeUIPrompt.text || ""}</textarea
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
                   </svg>
-                  ${queueLength > 0 && !periodicEnabled && html`<span class="queue-badge">${queueLength}</span>`}
+                  ${!periodicEnabled && html`<span class="queue-badge">${queueLength}</span>`}
                 </button>
+                `}
 
                 <!-- Prompts Toggle Button -->
                 ${hasPrompts &&
@@ -2797,6 +2785,21 @@ ${activeUIPrompt.text || ""}</textarea
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
                     </svg>
                   </button>
+                `}
+
+                <!-- Enqueue button: shown when streaming (so user can enqueue while agent works) -->
+                ${isStreaming && html`
+                <button
+                  type="button"
+                  onClick=${handleAddToQueueClick}
+                  disabled=${isFullyDisabled || (!text.trim() && !hasPendingAttachments) || isReadOnly || isImproving || periodicEnabled}
+                  class="chat-input-action"
+                  title=${periodicEnabled ? "Queue disabled for periodic sessions" : "Add to queue (⌘/Ctrl+Enter)"}
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                </button>
                 `}
 
                 <!-- Send/Stop/Lock button -->

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -2743,8 +2743,8 @@ ${activeUIPrompt.text || ""}</textarea
 
               <!-- Right action buttons: queue-toggle, prompts, enqueue, send/stop/lock -->
               <div class="chat-input-actions-right">
-                <!-- Queue toggle button: only shown when queue has items -->
-                ${queueLength > 0 && html`
+                <!-- Queue toggle button: shown when queue has items OR dropdown is open -->
+                ${(queueLength > 0 || showQueueDropdown) && html`
                 <button
                   type="button"
                   onClick=${() => {

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1521,11 +1521,11 @@ mitto-action {
   color: #e2e8f0;
 }
 
-/* Flat inline action button */
+/* Flat inline action button — matches p-1.5 rounded (28px, 4px radius) */
 .chat-input-action {
-  width: 30px;
-  height: 30px;
-  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
   background: transparent;
   border: none;
   color: #64748b;
@@ -1564,7 +1564,6 @@ mitto-action {
 .chat-input-action.send-active {
   background: #dc2626;
   color: #ffffff;
-  border-radius: 6px;
 }
 
 .chat-input-action.send-active:hover {
@@ -1582,7 +1581,6 @@ mitto-action {
 .chat-input-action.stop-active {
   background: #dc2626;
   color: #ffffff;
-  border-radius: 6px;
 }
 
 .chat-input-action.stop-active:hover {
@@ -1733,14 +1731,6 @@ mitto-action {
   background: #2563eb;
   border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-}
-
-/* Mobile: compact action buttons */
-@media (max-width: 768px) {
-  .chat-input-action {
-    width: 28px;
-    height: 28px;
-  }
 }
 
 /* Workspace pill clickable hover effect - uses filter instead of opacity


### PR DESCRIPTION
## Summary

Two small housekeeping changes:

### 1. Agent rules update (lessons from PR #48)
- Add TryLock post-processing pattern (release lock before slow work)
- Add `connected` handler `??` pattern (preserve existing values on reconnect)
- Add Hooks in Conditionals anti-pattern (extract sub-components)
- Add `omitempty`-on-bool rule (`false` is meaningful, not zero)
- Condense deadlock, JSON marshaling, layout, and toast sections

### 2. UI density improvements
- Reduce sidebar header icons (w-5 → w-4) and button padding (p-2 → p-1.5)
- Tighten button gaps and rounding for a more compact sidebar header
- Show queue toggle only when queue has items (declutter empty state)
- Show enqueue (+) button only during streaming (contextual action)
- Remove debug `console.log` from queue toggle handler
- Unify action button size to 28px with 4px radius (remove mobile-specific override)
