### PR TITLE
feat(processors): phase-based triggers, after-phase, cadence & persistence

### DIFF
--- a/.augment/rules/02-session.md
+++ b/.augment/rules/02-session.md
@@ -30,6 +30,7 @@ keywords:
 | `Lock`               | Session locking, heartbeat, cleanup         | Yes (mutex + goroutine) |
 | `Queue`              | Message queue for busy agent                | Yes (mutex)             |
 | `ActionButtonsStore` | Follow-up suggestions persistence           | Yes (mutex)             |
+| `PeriodicStore`      | Periodic prompt config per session          | Yes (mutex)             |
 | `Flags`              | Available feature flags registry            | N/A (read-only)         |
 
 ## Immediate Persistence (Web Interface)
@@ -93,50 +94,47 @@ lock.SetWaitingPermission("File write")  // During permission request
 
 ## Message Queue
 
-**Important**: Queue configuration is **global/workspace-scoped**, NOT per-session.
+**Important**: Queue configuration is **global/workspace-scoped**, NOT per-session. See [docs/devel/message-queue.md](../docs/devel/message-queue.md) for config options, REST API, WebSocket notifications, and title auto-generation.
 
-See [docs/devel/message-queue.md](../docs/devel/message-queue.md) for:
+## Periodic Prompts (PeriodicStore)
 
-- Configuration options and scope rationale
-- REST API endpoints
-- WebSocket notifications
-- Title auto-generation
+Stored in `periodic.json` per session. API: `GET/PUT/PATCH/DELETE /api/sessions/{id}/periodic`, `POST /api/sessions/{id}/periodic/run-now`.
+
+```go
+ps := store.Periodic(sessionID)
+ps.Set(&session.PeriodicPrompt{Prompt: "...", Frequency: ..., Enabled: true})
+ps.Update(prompt, frequency, enabled)  // partial update (pointer args, nil = no-op)
+ps.RecordSent()                         // updates last_sent_at + next_scheduled_at
+ps.TriggerNow(sessionID, resetTimer)    // immediate delivery via periodicRunner
+```
+
+**Key rules**:
+- Only top-level/parent sessions may have periodic prompts (child sessions return 400)
+- `PromptName` field (when added): references a named workspace prompt by name instead of embedding full text. `Validate()` must accept empty `Prompt` when `PromptName` is set. The periodic runner resolves the name to text at send time via the prompts cache.
+- **Caller update required**: Changing `PeriodicStore.Update()` signature requires updating **both** `internal/web/session_periodic_api.go` (PATCH handler) AND `internal/mcpserver/server.go` (MCP tool handler) — both call `Update()`.
 
 ## Auxiliary Package
 
-The `internal/auxiliary` package provides a hidden ACP session for utility tasks.
+The `internal/auxiliary` package provides a hidden ACP session for utility tasks. Lazy init, auto-approve permissions, file writes denied, thread-safe.
 
 ```go
-auxiliary.Initialize(acpCommand, logger)  // Once at startup
+auxiliary.Initialize(acpCommand, logger)
 title, err := auxiliary.GenerateTitle(ctx, userMessage)
-auxiliary.Shutdown()  // On exit
+auxiliary.Shutdown()
 ```
-
-**Key characteristics**: Lazy init, auto-approve permissions, file writes denied, thread-safe.
 
 ## Action Buttons Store
 
 The `ActionButtonsStore` persists follow-up suggestions to disk. See [docs/devel/follow-up-suggestions.md](../docs/devel/follow-up-suggestions.md) for full architecture.
 
 ```go
-// Get action buttons store for a session
 abStore := store.ActionButtons(sessionID)
-
-// Store suggestions after analysis
-abStore.Set(buttons, eventSeq)
-
-// Read suggestions (returns empty slice if none)
-buttons, err := abStore.Get()
-
-// Clear when user sends new prompt
-abStore.Clear()
+abStore.Set(buttons, eventSeq)   // after analysis
+abStore.Get()                    // returns empty slice if none
+abStore.Clear()                  // on new prompt
 ```
 
-**Key patterns**:
-
-- Separate file (`action_buttons.json`) - not in events.jsonl (transient UI state, not history)
-- Delete file on clear (vs writing empty) - reduces disk clutter
-- Two-tier cache in BackgroundSession: memory (fast) + disk (persistent)
+Stored in `action_buttons.json` (not events.jsonl). Delete on clear (vs writing empty). Two-tier cache in BackgroundSession: memory + disk.
 
 ## Feature Flags (AdvancedSettings)
 

--- a/.augment/rules/05-msghooks.md
+++ b/.augment/rules/05-msghooks.md
@@ -31,52 +31,62 @@ Prompt-mode processor auxiliary sessions have access to Mitto's MCP tools (e.g.,
 
 ```yaml
 name: my-processor
-when: first            # first | all | all-except-first
+when:                  # required block — BOTH on: and match: are required
+  on: userPrompt       # required: userPrompt | agentResponded
+  match: first         # required: first | all | allExceptFirst (NOT all-except-first)
+  rerun:               # optional; only valid with on:userPrompt + match:first
+    afterSentMsgs: 15
+    afterTokens: 50000
+    afterTime: 1h
+  # agentResponded-only (forbidden on userPrompt):
+  stopReasons: [end_turn]   # default ["end_turn"]; valid: end_turn max_tokens max_turn_requests refusal cancelled
+  excludeOrigins: []        # origins to skip: user queue periodic-runner mcp-send-prompt
+  cadence:             # optional throttle; only valid with on:agentResponded + match:all/allExceptFirst
+    everyNTurns: 3     # fire every N agent responses (pre-increment; everyNTurns:3 → turns 3,6,9,…)
+    everyNTokens: 15000 # AND: after N cumulative tokens since last firing
+    afterInterval: 5m  # AND: after this wall-clock duration since last firing
 priority: 100          # lower = earlier
 enabled: true          # false = never loads (build-time gate)
 enabledWhen: 'acp.matchesServerType("augment") && !session.isPeriodic'  # CEL runtime gate
 on_error: skip         # skip | fail
 
+# Text-mode only (forbidden for agentResponded):
+text: "static text"
+mutate: prepend        # prepend | append — REQUIRED when text: is set
+
 # Command-mode only:
 command: ./script.sh
 input: message         # message | conversation | none
 output: prepend        # transform | prepend | append | discard
+                       # transform/prepend/append FORBIDDEN for agentResponded
 
 # Prompt-mode only:
 prompt: |
   Analyze these messages: @mitto:messages   # legacy; see note below
 timeout: 300s
-
-# Auto re-run for when:first processors (whichever threshold fires first):
-rerun:
-  afterSentMsgs: 15    # message count since last run
-  afterTokens: 50000   # token usage since last run (falls back to char estimation)
-  afterTime: 1h        # elapsed time since last run
 ```
 
-## Two Enable Layers
+## Phase/Field Rules
 
-| Layer         | Field          | Skip reason logged      | Effect                                 |
-| ------------- | -------------- | ----------------------- | -------------------------------------- |
-| Build-time    | `enabled: false` | not loaded at all      | Processor never appears in pipeline    |
-| Runtime (CEL) | `enabledWhen`  | `enabledWhen_false`     | Processor is loaded but skipped        |
+| Field / output              | `on: userPrompt`      | `on: agentResponded`         |
+| --------------------------- | --------------------- | ---------------------------- |
+| `text:`                     | ✅                    | ❌ forbidden                 |
+| `mutate:` (req w/ text)     | ✅                    | ❌ forbidden                 |
+| `command:` / `prompt:`      | ✅                    | ✅                           |
+| `when.rerun:`               | ✅ (match:first only) | ❌ forbidden                 |
+| `when.stopReasons:`         | ❌ forbidden          | ✅ default `[end_turn]`      |
+| `when.excludeOrigins:`      | ❌ forbidden          | ✅                           |
+| `output: transform/prepend/append` | ✅           | ❌ forbidden                 |
+| `output: discard`           | ✅                    | ✅                           |
+| `output: notify`            | ❌                    | ✅ JSON `{title,message,style}` or plain text |
+| `output: actionButtons`     | ❌                    | ✅ JSON `[{label,prompt},…]` |
+| `output: userData`          | ❌                    | ✅ JSON `{key:value}` patch  |
 
-When a processor has both `enabled: false` and `enabledWhen`, it is never loaded regardless of the CEL result.
+`Manager.ApplyAfter()` runs agentResponded processors; results (`ApplyAfterResult`) are consumed by `BackgroundSession.applyAfterProcessors()` → notifications via `OnNotification`, action buttons via the existing store, user-data via atomic write.
 
-## `@mitto:messages` Substitution
+**Enable layers**: `enabled: false` → never loaded; `enabledWhen` (CEL) → loaded but skipped at runtime. Both together = never loaded.
 
-The `@mitto:messages` placeholder (plus `messages:` YAML block) is **supported for backward compatibility** in user-defined processors. Builtin processors have migrated to using the `mitto_conversation_history` MCP tool instead — the agent calls the tool directly to fetch filtered history. Do NOT add new `messages:` blocks to builtin YAML files.
-
-## Adding New `@mitto:` Variables (Checklist)
-
-New substitution variables (e.g. `@mitto:periodic_forced`) require changes in four files:
-
-| File | Change |
-|------|--------|
-| `internal/web/background_session.go` | Add field to `PromptMeta` struct; wire it in `PromptWithMeta` → `processorInput` |
-| `internal/processors/input.go` | Add field to `ProcessorInput` struct (with json tag) |
-| `internal/processors/variables.go` | Add substitution case in `SubstituteVariables`; update doc comment |
-| Callers (e.g. `periodic_runner.go`) | Pass the value when constructing `PromptMeta` |
+**`@mitto:messages`**: legacy substitution; builtins use `mitto_conversation_history` MCP tool directly instead. Do NOT add new `messages:` blocks to builtin YAML files.
 
 ## Builtin Processors (`config/processors/builtin/`)
 
@@ -98,16 +108,9 @@ processors:
 | `cleanup-children`    | command | _(varies)_                                                      | Archive stale child sessions       |
 | `auggie-manage-rules` | prompt  | `acp.matchesServerType("augment") && !session.isPeriodic`       | Maintain `.augment/rules/` files   |
 | `claude-manage-memory`| prompt  | `acp.matchesServerType("claude-code") && !session.isPeriodic`   | Maintain `CLAUDE.md` / `.claude/`  |
-| `memorize-preferences`| prompt  | `!session.isPeriodic`                                           | Save user prefs to `AGENTS.md`     |
-| `identify-user-data`  | prompt  | `workspace.hasUserDataSchema && !session.isPeriodic`            | Auto-fill workspace user data fields|
+| `memorize-preferences`| prompt  | `!session.isPeriodic`                                           | Save user prefs to `AGENTS.md` (agentResponded, cadence: every 5 turns/30k tokens/5m) |
+| `identify-user-data`  | prompt  | `workspace.hasUserDataSchema && !session.isPeriodic`            | Auto-fill workspace user data fields (agentResponded, cadence: every 3 turns/15k tokens) |
 | `identify-workspace-metadata` | prompt | `workspace.hasMittoRC && !workspace.hasMetadataDescription && !session.isPeriodic` | Auto-fill `metadata.description` and `metadata.url` in `.mittorc` |
-
-**Common skip reasons:**
-- `enabledWhen_false` — CEL expression evaluated to false (e.g., wrong server type, tools already present)
-- `check-mcp-tools` skipped when mitto tools already available → `tools.hasPattern("mitto_*")` is true
-- `auggie-manage-rules` skipped when using Claude Code → `acp.matchesServerType("augment")` is false
-- `identify-user-data` skipped when no user data schema in `.mittorc` → `workspace.hasUserDataSchema` is false
-- `identify-workspace-metadata` skipped when no `.mittorc` or description already set → `workspace.hasMittoRC && !workspace.hasMetadataDescription`
 
 ## CEL Context for `enabledWhen`
 
@@ -123,28 +126,29 @@ Key CEL variables/functions (full reference in `docs/config/processors.md`):
 | `fileExists(path)`    | `fileExists("Makefile")`, `fileExists("go.mod")` — checks if file exists (not directory); workspace-relative |
 | `dirExists(path)`     | `dirExists(".github")`, `dirExists("src")` — checks if directory exists; workspace-relative |
 
-## Skip Reason Reference
+## Skip Reasons & Common Pitfalls
 
-| Log `reason=`       | Cause                                                   |
-| ------------------- | ------------------------------------------------------- |
-| `enabled_false`     | `enabled: false` in YAML and no workspace override      |
-| `enabledWhen_false` | CEL expression evaluated to false                       |
-| `when_mismatch`     | `when: first` processor on a non-first message          |
+| Log `reason=`       | Cause                                               |
+| ------------------- | --------------------------------------------------- |
+| `enabled_false`     | `enabled: false` in YAML, no workspace override     |
+| `enabledWhen_false` | CEL expression evaluated to false                   |
+| `when_mismatch`     | `match: first` processor on a non-first message     |
 
-## Command Resolution
+Common mistakes rejected by the loader:
+- **Missing `on:` or `match:`** — both required
+- **`sent:` key** — old syntax; use `on: userPrompt` + `match: <value>`
+- **`all-except-first`** (kebab) — use `allExceptFirst` (camelCase)
+- **Text-mode without `mutate:`** — required; `prepend` or `append`
+- **`rerun:` with `match: all`** — only valid with `match: first`
+- **`cadence:` with `on: userPrompt`** — only valid with `agentResponded` (rule 12)
+- **`cadence:` with `match: first`** — not valid; firing once needs no cadence (rule 13)
+- **`cadence:` with no threshold fields** — at least one must be set (rule 14)
+- **Negative `everyNTurns`/`everyNTokens`** — must be non-negative (rule 15)
+- **Unparseable `afterInterval`** — must be a valid Go duration string like `"5m"` (rule 16)
 
-- `./` or `../` prefix → relative to processor file directory
-- Absolute path → used as-is
-- Otherwise → PATH lookup
+`cadence` and `rerun` are mutually exclusive by construction: `rerun` only applies to `on:
+userPrompt` and `cadence` only applies to `on: agentResponded`.
 
 ## Defaults
 
-| Field         | Default   |
-| ------------- | --------- |
-| `enabled`     | true      |
-| `timeout`     | 5s (300s for prompt-mode) |
-| `priority`    | 100       |
-| `input`       | message   |
-| `output`      | transform |
-| `working_dir` | session   |
-| `on_error`    | skip      |
+`command` paths: `./`/`../` → processor dir; absolute; otherwise PATH. Defaults: `enabled=true`, `timeout=5s` (300s prompt-mode), `priority=100`, `input=message`, `output=transform`, `working_dir=session`, `on_error=skip`.

--- a/.augment/rules/20-web-frontend-core.md
+++ b/.augment/rules/20-web-frontend-core.md
@@ -60,6 +60,7 @@ App
 | `utils/api.js`                 | API URL helpers with prefix handling          |
 | `utils/storage.js`             | localStorage utilities                        |
 | `utils/native.js`              | macOS app detection and native functions      |
+| `utils/models.js`              | Model context window sizes (`MODEL_CONTEXT_WINDOWS`, `getContextWindowSize`) |
 
 ## lib.js Core Functions
 
@@ -146,5 +147,3 @@ useEffect(() => {
 1. **`useWebSocket.js`** — In `case "connected":` handler, add to session.info
 2. **`app.js`** — Pass as prop: `myCapability=${sessionInfo?.my_capability ?? false}`
 3. **Component** — Accept prop with default, use for conditional rendering
-
-

--- a/.augment/rules/25-web-frontend-components.md
+++ b/.augment/rules/25-web-frontend-components.md
@@ -56,9 +56,9 @@ All components use Preact/HTM with window globals: `const { useState, useEffect,
 Single bordered container: textarea (no own border) + bottom toolbar with left/center/right sections.
 
 - **Outer container**: provides border and rounded corners — textarea has no own border
-- **Bottom toolbar left**: attach-image, attach-file, improve-prompt, save-prompt
-- **Bottom toolbar center**: model selector (only shown when `configOptions` contains a `type === "select"` option)
-- **Bottom toolbar right**: prompts-toggle, queue-toggle (visible when queue non-empty or dropdown open), enqueue (visible while streaming), send/stop/lock
+- **Bottom toolbar left**: improve-prompt (magic wand), attach-image, attach-file, save-prompt (native only), clear/delete
+- **Bottom toolbar center**: config selectors (model, mode — only when `configOptions` has `type === "select"`) + context usage percentage
+- **Bottom toolbar right**: queue-toggle (visible when queue non-empty or dropdown open), prompts-toggle, enqueue (visible while streaming), send/stop/lock
 - **No floating action-toolbar** — all actions are in the always-visible bottom bar
 
 > **Anti-pattern**: Do NOT use the old "textarea + external button column" layout. The floating toolbar that appeared on focus has been removed.
@@ -79,13 +79,15 @@ const selectConfigOptions = useMemo(() => {
 - CSS classes: `chat-input-model-selector` (container) / `chat-input-model-select` (each `<select>`)
 - **Anti-pattern**: Do NOT use `find()` to show only the first option — use `filter()` to show all
 
+### Context Usage Percentage (center bar)
+
+**Primary**: `context_usage` from ACP `SessionUsageUpdate` — UNSTABLE; most agents don't send it.
+**Fallback**: `tokenUsage.input_tokens ÷ getContextWindowSize(modelId)` from `utils/models.js`.
+Always implement both: the primary path will silently produce nothing if the agent doesn't support it.
+
 ### Keyboard Shortcuts
 
-| Keys             | Action       |
-| ---------------- | ------------ |
-| `Enter`          | Send message |
-| `Shift+Enter`    | New line     |
-| `Cmd/Ctrl+Enter` | Add to queue |
+**Shortcuts**: `Enter`=send · `Shift+Enter`=new line · `Cmd/Ctrl+Enter`=queue
 
 ## QueueDropdown
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,4 +96,7 @@ bd close <id>         # Complete work
 - **Prompt auto-rename**: Prompts that run in a named context (e.g., a specific repo or project) should auto-rename the conversation with `mitto_conversation_update` at the start. Use `@mitto:conversation_title` to check the current title and skip the update if it's already correct.
 - **Terminology consistency**: Use "conversation" (not "session") in all user-facing UI text, labels, and headings. Keep "session" only in internal code identifiers and API paths where it's already established.
 - **Dialog button conventions**: Use "Save" (not "Save changes") as the save button label. Use "Close" (not "Cancel") to dismiss dialogs. "Save" should save without closing — the user must press "Close" separately. This enables flows that require saving settings before continuing.
+- **UI button consistency**: All toolbar buttons and button groups must use the same size, border style, and spacing. When multiple button groups appear in a row, maintain uniform appearance across all of them.
+- **YAML enum naming**: Use camelCase (not kebab-case) for YAML enum values and field names in processor/prompt configuration (e.g., `allExceptFirst` not `all-except-first`, `afterSentMsgs` not `after-sent-msgs`).
+- **No backwards compatibility shims**: When changing configuration syntax or field names, migrate all code, tests, docs, and definitions in one pass. Do not add backwards compatibility layers or fallback parsing for old formats.
 <!-- END USER PREFERENCES -->

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -150,9 +150,10 @@ web:
 
 # Conversation processing - transformations applied to user messages
 # Processors are applied in order. Each processor specifies:
-#   - when: "first" (first message only), "all" (every message), "all-except-first"
-#   - position: "prepend" (before message) or "append" (after message)
-#   - text: the content to insert
+#   - when.on:    "userPrompt" (before sending to agent) or "agentResponded" (after agent reply)
+#   - when.match: "first" (first message only), "all" (every message), "allExceptFirst"
+#   - mutate: "prepend" (before message) or "append" (after message)  [userPrompt only]
+#   - text: the content to insert  [userPrompt only]
 #
 # Global processors defined here apply to all workspaces.
 # Workspace-specific processors can be defined in <workspace>/.mittorc
@@ -162,8 +163,10 @@ web:
 #   processing:
 #     processors:
 #       # Add system context to the first message
-#       - when: first
-#         position: prepend
+#       - when:
+#           on: userPrompt
+#           match: first
+#         mutate: prepend
 #         text: |
 #           You are a helpful AI coding assistant.
 #           Please follow best practices and be concise.
@@ -171,13 +174,17 @@ web:
 #           ---
 #
 #       # Add a reminder to all messages
-#       - when: all
-#         position: append
+#       - when:
+#           on: userPrompt
+#           match: all
+#         mutate: append
 #         text: "\n\n[Remember: Provide working code examples]"
 #
 #       # Add continuation context after the first message
-#       # - when: all-except-first
-#       #   position: prepend
+#       # - when:
+#       #     on: userPrompt
+#       #     match: allExceptFirst
+#       #   mutate: prepend
 #       #   text: "[Continuing from previous context]\n\n"
 #
 #   # Message queue configuration

--- a/config/processors/builtin/auggie-manage-rules.yaml
+++ b/config/processors/builtin/auggie-manage-rules.yaml
@@ -15,13 +15,15 @@
 name: auggie-manage-rules
 description: "Generate and maintain .augment/rules/ files from workspace analysis and conversations"
 enabled: true
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 10
+    afterTokens: 40000
 priority: 200
 timeout: 300s
 on_error: skip
-rerun:
-  afterSentMsgs: 10
-  afterTokens: 40000
 
 # Only for Auggie sessions, skip periodic prompts
 enabledWhen: 'acp.matchesServerType("augment") && !session.isPeriodic'

--- a/config/processors/builtin/check-mcp-tools.yaml
+++ b/config/processors/builtin/check-mcp-tools.yaml
@@ -11,13 +11,15 @@ name: check-mcp-tools
 description: "Checks if Mitto MCP tools are available and suggests installation"
 enabled: true
 enabledWhen: '!tools.hasPattern("mitto_*")'
-when: first
-position: append
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 20m
+    afterSentMsgs: 15
+    afterTokens: 60000
+mutate: append
 priority: 15
-rerun:
-  afterTime: 20m
-  afterSentMsgs: 15
-  afterTokens: 60000
 text: |
   ---
   [Mitto MCP Tools Check]

--- a/config/processors/builtin/claude-manage-memory.yaml
+++ b/config/processors/builtin/claude-manage-memory.yaml
@@ -15,13 +15,15 @@
 name: claude-manage-memory
 description: "Generate and maintain Claude Code memory files from workspace analysis and conversations"
 enabled: true
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 15
+    afterTokens: 60000
 priority: 200
 timeout: 300s
 on_error: skip
-rerun:
-  afterSentMsgs: 15
-  afterTokens: 60000
 
 # Only for Claude Code sessions, skip periodic prompts
 enabledWhen: 'acp.matchesServerType("claude-code") && !session.isPeriodic'

--- a/config/processors/builtin/cleanup-children.yaml
+++ b/config/processors/builtin/cleanup-children.yaml
@@ -16,13 +16,15 @@
 name: cleanup-children
 description: "Reminds the agent to clean up child conversations it no longer needs"
 enabled: true
-when: first
-position: append
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 10
+    afterTime: 15m
+    afterTokens: 40000
+mutate: append
 priority: 95
-rerun:
-  afterSentMsgs: 10
-  afterTime: 15m
-  afterTokens: 40000
 enabledWhen: 'children.mcpCount >= 2 && tools.hasPattern("mitto_conversation_delete_*")'
 text: |
   ---

--- a/config/processors/builtin/delegate-playwright.yaml
+++ b/config/processors/builtin/delegate-playwright.yaml
@@ -19,13 +19,15 @@
 name: delegate-playwright
 description: "Delegates Playwright browser automation to a faster model when using a premium reasoning model"
 enabled: true
-when: first
-position: append
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 30m
+    afterSentMsgs: 20
+    afterTokens: 80000
+mutate: append
 priority: 91
-rerun:
-  afterTime: 30m
-  afterSentMsgs: 20
-  afterTokens: 80000
 enabledWhen: >-
   (acp.tags.exists(t, t == "reasoning")
   || acp.tags.exists(t, t == "thinking")

--- a/config/processors/builtin/delegate-to-coder.yaml
+++ b/config/processors/builtin/delegate-to-coder.yaml
@@ -14,13 +14,15 @@
 name: delegate-to-coder
 description: "Suggests delegating coding tasks to a faster model when using a premium reasoning model"
 enabled: true
-when: first
-position: append
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 30m
+    afterSentMsgs: 20
+    afterTokens: 80000
+mutate: append
 priority: 90
-rerun:
-  afterTime: 30m
-  afterSentMsgs: 20
-  afterTokens: 80000
 enabledWhen: >-
   acp.tags.exists(t, t == "reasoning")
   || acp.tags.exists(t, t == "thinking")

--- a/config/processors/builtin/identify-user-data.yaml
+++ b/config/processors/builtin/identify-user-data.yaml
@@ -15,13 +15,16 @@
 name: identify-user-data
 description: "Detects user data values from conversations and sets them via MCP"
 enabled: true
-when: first
+when:
+  on: agentResponded
+  match: all
+  stopReasons: [end_turn]
+  cadence:
+    everyNTurns: 3
+    everyNTokens: 15000
 priority: 190
 timeout: 120s
 on_error: skip
-rerun:
-  afterSentMsgs: 5
-  afterTokens: 15000
 
 # Only activate when the workspace has a user data schema and this isn't a periodic prompt
 enabledWhen: 'workspace.hasUserDataSchema && !session.isPeriodic'
@@ -55,7 +58,8 @@ prompt: |
 
   ## Your Task
 
-  1. Go through the latest messages in the conversation history.
+  1. Go through the latest user messages and agent messages in the conversation history
+     (look at both — the agent may have confirmed or echoed values that the user mentioned).
   2. For each field in the schema, check whether the messages contain information that
      matches the field's description.
   3. **Only extract values you are confident about.** Do not guess or fabricate values.
@@ -97,8 +101,8 @@ prompt: |
   Call it with:
   - `self_id`: your session ID (from `mitto_conversation_get_current`)
   - `conversation_id`: "@mitto:session_id"
-  - `event_types`: ["user_prompt"]
-  - `last_n`: 15
+  - `event_types`: ["user_prompt", "agent_message"]
+  - `last_n`: 10
 
   Review these messages for user data field values.
 

--- a/config/processors/builtin/identify-workspace-metadata.yaml
+++ b/config/processors/builtin/identify-workspace-metadata.yaml
@@ -14,7 +14,9 @@
 name: identify-workspace-metadata
 description: "Analyzes the project and fills in workspace metadata (description, URL) in .mittorc"
 enabled: true
-when: first
+when:
+  on: userPrompt
+  match: first
 priority: 195
 timeout: 120s
 on_error: skip

--- a/config/processors/builtin/memorize-preferences.yaml
+++ b/config/processors/builtin/memorize-preferences.yaml
@@ -27,13 +27,17 @@
 name: memorize-preferences
 description: "Extracts user preferences from conversations and saves them to AGENTS.md"
 enabled: true
-when: first
+when:
+  on: agentResponded
+  match: all
+  stopReasons: [end_turn]
+  cadence:
+    everyNTurns: 5
+    everyNTokens: 30000
+    afterInterval: 5m
 priority: 200
 timeout: 120s
 on_error: skip
-rerun:
-  afterSentMsgs: 10
-  afterTokens: 30000
 
 # Skip periodic prompts — only process real user messages
 enabledWhen: '!session.isPeriodic'
@@ -78,8 +82,8 @@ prompt: |
   Call it with:
   - `self_id`: your session ID (from `mitto_conversation_get_current`)
   - `conversation_id`: "@mitto:session_id"
-  - `event_types`: ["user_prompt"]
-  - `last_n`: 20
+  - `event_types`: ["user_prompt", "agent_message"]
+  - `last_n`: 12
 
   Review these messages for user preferences and conventions.
 

--- a/config/processors/builtin/session-context.yaml
+++ b/config/processors/builtin/session-context.yaml
@@ -9,13 +9,15 @@
 name: session-context
 description: "Injects session identity and context into the first message"
 enabled: true
-when: first
-position: prepend
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 30m
+    afterSentMsgs: 20
+    afterTokens: 80000
+mutate: prepend
 priority: 10
-rerun:
-  afterTime: 30m
-  afterSentMsgs: 20
-  afterTokens: 80000
 text: |
   [Session Context]
   Session: @mitto:session_id (@mitto:session_name)

--- a/docs/config/processors.md
+++ b/docs/config/processors.md
@@ -1,11 +1,15 @@
 # Processors Configuration
 
-Mitto supports processors that transform messages before sending them to the ACP
-server. There are three modes:
+Mitto supports processors that can run at two points in the conversation lifecycle:
 
-- **Text-mode** — Inject static text (with optional variable substitution) into messages. No external commands needed.
-- **Command-mode** — Execute external commands that receive message context as JSON and produce transformed output.
-- **Prompt-mode** — Send a prompt (with conversation history) to a workspace-scoped auxiliary AI agent. Fire-and-forget: the pipeline continues immediately without waiting for the agent's response.
+- **`on: userPrompt`** — Processors fire *before* the user's message is sent to the ACP agent. This is the standard phase for injecting context, prepending reminders, running scripts, or dispatching background prompts.
+- **`on: agentResponded`** — Processors fire *after* the agent finishes a turn. Only command-mode and prompt-mode are allowed here (text injection is not meaningful post-response). Data-extraction processors that benefit from seeing the agent's reply (e.g., `identify-user-data`, `memorize-preferences`) run in this phase.
+
+Within each phase, three execution modes are available:
+
+- **Text-mode** — Inject static text (with optional variable substitution) into the message. No external commands needed. Only valid for `on: userPrompt`.
+- **Command-mode** — Execute external commands that receive message context as JSON and produce transformed output. Valid for both phases.
+- **Prompt-mode** — Send a prompt to a workspace-scoped auxiliary AI agent. Fire-and-forget: the pipeline continues immediately. Valid for both phases.
 
 ## Configuration in the UI
 
@@ -16,12 +20,12 @@ Processors are managed per-workspace in the **Workspaces → Processors** tab:
 From this tab you can:
 
 - **Enable/disable** any processor using the checkbox — global processors can be disabled per workspace
-- See each processor's **source** (workspace, global, or built-in), **mode** (text, command, or prompt), and **trigger** (when: first, all, etc.)
+- See each processor's **source** (workspace, global, or built-in), **mode** (text, command, or prompt), and **trigger** (phase + match)
 
 Each processor shows badges indicating:
 - **Source**: `global` (orange), `workspace` (green), or `built-in` (blue)
 - **Mode**: `prompt` badge for prompt-mode processors
-- **Trigger**: `when: first`, `when: all`, etc.
+- **Trigger**: `on: userPrompt / match: first`, etc.
 
 ---
 
@@ -82,8 +86,10 @@ conversations:
     override: false
 
     processors:
-      - when: first        # "first", "all", or "all-except-first"
-        position: prepend   # "prepend" or "append"
+      - when:
+          on: userPrompt    # "userPrompt" (before sending) or "agentResponded" (after response)
+          match: first      # "first", "all", or "allExceptFirst"
+        mutate: prepend     # "prepend" or "append" (text-mode only; required for text mode)
         text: |
           You are a helpful AI coding assistant.
           Follow best practices and be concise.
@@ -91,7 +97,9 @@ conversations:
           ---
 ```
 
-Inline processors are merged with standalone processor files (see merge behavior above). They support the same `when`, `position`, and `text` fields as text-mode processor files, plus `@mitto:variable` substitution.
+> **Note:** Inline `.mittorc` processors support `on:` and `match:` only — the `rerun:`, `stopReasons:`, and `excludeOrigins:` sub-fields are not available for inline processors. For processors that need `rerun`, use standalone YAML files instead (see [Full Configuration Schema](#full-configuration-schema)).
+
+Inline processors are merged with standalone processor files (see merge behavior above). They support the same `when`, `mutate`, and `text` fields as text-mode processor files, plus `@mitto:variable` substitution. The `when:` block requires both `on:` and `match:` fields.
 
 When both global and workspace `.mittorc` files define inline processors:
 
@@ -134,18 +142,18 @@ Mitto ships with builtin processors that are automatically deployed to `MITTO_DI
 
 ### Included Builtin Processors
 
-| Processor             | Description                                                                                              | When    | Mode   | Enabled                                            |
-| --------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ------ | -------------------------------------------------- |
-| `session-context`     | Injects session identity, parent/child relationships, and available agents into the first message        | `first` | text   | Yes                                                |
-| `check-mcp-tools`     | Checks if Mitto MCP tools are available and suggests installation if missing                             | `first` | text   | Yes                                                |
-| `delegate-to-coder`   | Suggests delegating coding tasks to a faster model when using a premium reasoning model (Opus, o3, etc.) | `first` | text   | Yes (only activates for matching ACP servers)      |
-| `delegate-playwright` | Delegates Playwright browser automation to a faster model when using a premium reasoning model           | `first` | text   | Yes (requires smart model + `browser_*` MCP tools) |
-| `cleanup-children`    | Reminds the agent to clean up child conversations it no longer needs                                     | `first` | text   | Yes (requires ≥2 MCP-created children + delete tool) |
-| `memorize-preferences`| Extracts user preferences from conversations and saves them to AGENTS.md                                 | `first` | prompt | **Yes** (disable in Workspaces dialog or `.mittorc`) |
-| `auggie-manage-rules` | Generates and maintains `.augment/rules/` from workspace analysis and conversations (every 15 messages)   | `first` | prompt | **Yes** (Auggie only; disable per workspace if unwanted) |
-| `claude-manage-memory`| Generates and maintains Claude Code memory files from workspace analysis and conversations (every 15 msgs)| `first` | prompt | **Yes** (Claude Code only; disable per workspace if unwanted) |
-| `identify-user-data`  | Detects user data values from conversations and sets them via MCP (every 5 messages)                      | `first` | prompt | **Yes** (only activates when `user_data` schema is defined in `.mittorc`) |
-| `identify-workspace-metadata` | Analyzes the project and fills in `metadata.description` and `metadata.url` in `.mittorc` when missing | `first` | prompt | **Yes** (only fires when `.mittorc` exists but lacks a description) |
+| Processor             | Description                                                                                              | Phase / Match | Mode   | Enabled                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------------- | ------------- | ------ | -------------------------------------------------- |
+| `session-context`     | Injects session identity, parent/child relationships, and available agents into the first message        | userPrompt / first | text   | Yes                                                |
+| `check-mcp-tools`     | Checks if Mitto MCP tools are available and suggests installation if missing                             | userPrompt / first | text   | Yes                                                |
+| `delegate-to-coder`   | Suggests delegating coding tasks to a faster model when using a premium reasoning model (Opus, o3, etc.) | userPrompt / first | text   | Yes (only activates for matching ACP servers)      |
+| `delegate-playwright` | Delegates Playwright browser automation to a faster model when using a premium reasoning model           | userPrompt / first | text   | Yes (requires smart model + `browser_*` MCP tools) |
+| `cleanup-children`    | Reminds the agent to clean up child conversations it no longer needs                                     | userPrompt / first | text   | Yes (requires ≥2 MCP-created children + delete tool) |
+| `memorize-preferences`| Extracts user preferences from conversations and saves them to AGENTS.md                                 | agentResponded / all | prompt | **Yes** (disable in Workspaces dialog or `.mittorc`) |
+| `auggie-manage-rules` | Generates and maintains `.augment/rules/` from workspace analysis and conversations (every 15 messages)   | userPrompt / first | prompt | **Yes** (Auggie only; disable per workspace if unwanted) |
+| `claude-manage-memory`| Generates and maintains Claude Code memory files from workspace analysis and conversations (every 15 msgs)| userPrompt / first | prompt | **Yes** (Claude Code only; disable per workspace if unwanted) |
+| `identify-user-data`  | Detects user data values from conversations and sets them via MCP (every 3 turns or 15k tokens)           | agentResponded / all | prompt | **Yes** (only activates when `user_data` schema is defined in `.mittorc`) |
+| `identify-workspace-metadata` | Analyzes the project and fills in `metadata.description` and `metadata.url` in `.mittorc` when missing | userPrompt / first | prompt | **Yes** (only fires when `.mittorc` exists but lacks a description) |
 
 ### Managing Builtin Processors
 
@@ -167,8 +175,10 @@ reminders, or instructions to conversations.
 ```yaml
 name: my-reminder
 description: "Adds a coding reminder to every message"
-when: all
-position: append
+when:
+  on: userPrompt   # required: "userPrompt" or "agentResponded"
+  match: all       # required: "first", "all", or "allExceptFirst"
+mutate: append     # required for text mode: "prepend" or "append"
 priority: 100
 text: |
   ---
@@ -183,8 +193,10 @@ text: |
 ```yaml
 name: project-context
 description: "Adds project context to the first message"
-when: first
-position: prepend
+when:
+  on: userPrompt
+  match: first
+mutate: prepend
 priority: 20
 text: |
   [Project Context]
@@ -199,8 +211,10 @@ text: |
 ```yaml
 name: safety-reminder
 description: "Reminds the agent about safe practices"
-when: all
-position: append
+when:
+  on: userPrompt
+  match: all
+mutate: append
 priority: 200
 text: |
   ---
@@ -216,12 +230,14 @@ live session values (see [Variable Substitution](#variable-substitution) below).
 ```yaml
 name: session-context
 description: "Injects session identity and context"
-when: first
-position: prepend
+when:
+  on: userPrompt
+  match: first
+  rerun:           # optional; only valid with on:userPrompt + match:first
+    afterTime: 30m
+    afterSentMsgs: 20
+mutate: prepend
 priority: 10
-rerun:
-  afterTime: 30m
-  afterSentMsgs: 20
 text: |
   [Session Context]
   Session: @mitto:session_id (@mitto:session_name)
@@ -238,8 +254,10 @@ text: |
 ```yaml
 name: reasoning-guidance
 description: "Delegation guidance for premium reasoning models"
-when: first
-position: append
+when:
+  on: userPrompt
+  match: first
+mutate: append
 priority: 90
 enabledWhen: 'acp.tags.exists(t, t == "reasoning")'
 text: |
@@ -271,12 +289,14 @@ MCP tool at runtime.
 ```yaml
 name: my-analyzer
 description: "Analyzes conversations in the background"
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 10
 priority: 200
 timeout: 120s
 on_error: skip
-rerun:
-  afterSentMsgs: 10
 
 prompt: |
   Analyze recent conversation messages and extract key insights.
@@ -291,7 +311,7 @@ prompt: |
 
 ### Key Differences from Text/Command Mode
 
-- **No `position` or `output` fields** — prompt-mode processors don't modify the outgoing message
+- **No `mutate` or `output` fields** — prompt-mode processors don't modify the outgoing message
 - **Always asynchronous** — the pipeline never blocks waiting for the auxiliary agent
 - **Requires a workspace** — the auxiliary session is scoped to the workspace
 - **Requires an auxiliary ACP server** — configured in the workspace settings
@@ -309,12 +329,14 @@ pattern — see [Builtin Processors](#builtin-processors).
 ```yaml
 name: progress-summary
 description: "Summarizes session progress periodically"
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 15
 priority: 200
 timeout: 120s
 on_error: skip
-rerun:
-  afterSentMsgs: 15
 
 prompt: |
   Review the recent conversation and write a brief progress summary.
@@ -329,12 +351,14 @@ prompt: |
 ```yaml
 name: action-items
 description: "Extracts TODO items from agent responses"
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 10
 priority: 200
 timeout: 60s
 on_error: skip
-rerun:
-  afterSentMsgs: 10
 
 prompt: |
   Look through the agent's responses for any TODO items, action items,
@@ -351,50 +375,124 @@ Each YAML file in the processors directory defines one processor. Use **either**
 
 ```yaml
 # Required fields
-name: my-processor # Human-readable identifier
-when: first # "first", "all", or "all-except-first"
+name: my-processor   # Human-readable identifier
+when:                # Trigger condition — always a block
+  on: userPrompt     # Phase: "userPrompt" (before send) or "agentResponded" (after response)
+  match: first       # Match: "first", "all", or "allExceptFirst"
+  rerun:             # Optional: auto re-run — only valid with on:userPrompt + match:first
+    afterTime: 30m          # re-run after 30 minutes since last run
+    afterSentMsgs: 20       # re-run after 20 user messages since last run
+    afterTokens: 50000      # re-run after 50000 tokens consumed since last run
+  # agentResponded-only fields (forbidden for userPrompt):
+  stopReasons:       # which ACP stop reasons trigger this processor (default: ["end_turn"])
+    - end_turn       # valid values: end_turn, max_tokens, max_turn_requests, refusal, cancelled
+  excludeOrigins:    # skip processor when message origin matches any of these
+    - periodic-runner
 
 # --- Text-mode (use ONE of the three modes) ---
-text: | # Static text to inject (no command needed)
+# Only valid for on:userPrompt; forbidden for on:agentResponded
+text: |  # Static text to inject
   Your static content here.
 
 # --- Command-mode (use ONE of the three modes) ---
-command: /path/to/script.sh # Command to execute (see Command Resolution)
+command: /path/to/script.sh  # Command to execute (see Command Resolution)
 
 # --- Prompt-mode (use ONE of the three modes) ---
-prompt: | # Prompt template for auxiliary AI agent (fire-and-forget)
+prompt: |  # Prompt template for auxiliary AI agent (fire-and-forget)
   Session: @mitto:session_id
   Use mitto_conversation_history to retrieve messages and analyze them.
 
 # Optional fields
-description: "Adds context" # Description of what the processor does
-enabled: true # Default: true
-position: prepend # "prepend" or "append" (default: prepend; text/command-mode only)
-priority: 100 # Execution order, lower = earlier (default: 100)
+description: "Adds context"  # Description of what the processor does
+enabled: true                # Default: true
+mutate: prepend              # "prepend" or "append" (text-mode only; required for text mode)
+priority: 100                # Execution order, lower = earlier (default: 100)
 
-# I/O configuration (text/command-mode only; ignored for prompt-mode)
-input: message # "message", "conversation", or "none" (default: message)
+# I/O configuration (command-mode only; ignored for text/prompt-mode)
+input: message   # "message", "conversation", or "none" (default: message)
 output: transform # "transform", "prepend", "append", "discard" (default: transform)
+                  # NOTE: transform/prepend/append are forbidden for on:agentResponded
 
 # Execution settings
-timeout: 5s # Command timeout (default: 5s); also caps auxiliary agent time in prompt-mode
-working_dir: session # "session" or "hook" (default: session)
-on_error: skip # "skip" or "fail" (default: skip)
+timeout: 5s       # Command timeout (default: 5s); also caps auxiliary agent time in prompt-mode
+working_dir: session  # "session" or "hook" (default: session)
+on_error: skip    # "skip" or "fail" (default: skip)
 
-# Environment variables (in addition to automatic ones; text/command-mode only)
+# Environment variables (in addition to automatic ones; command-mode only)
 environment:
   MY_VAR: "value"
 
 # CEL expression for conditional activation (empty = always apply)
 # Same context as prompt enabledWhen: acp.*, session.*, parent.*, children.*, workspace.*, tools.*
 enabledWhen: 'acp.tags.exists(t, t == "reasoning") && tools.hasAllPatterns(["mitto_conversation_*", "jira_*"])'
-
-# Automatic re-run for "when: first" processors (refreshes context periodically)
-rerun:
-  afterTime: 30m # re-run after 30 minutes since last run
-  afterSentMsgs: 20 # re-run after 20 user messages since last run
-  afterTokens: 50000 # re-run after 50000 tokens consumed since last run
 ```
+
+### `when:` Block Reference
+
+The `when:` block is required for all processors. Both `on:` and `match:` are required fields.
+
+| Field               | Values                                           | Required | Notes                                              |
+| ------------------- | ------------------------------------------------ | -------- | -------------------------------------------------- |
+| `on`                | `userPrompt` \| `agentResponded`                 | ✅ Yes   | Phase when the processor fires                     |
+| `match`             | `first` \| `all` \| `allExceptFirst`             | ✅ Yes   | Which messages in the sequence to fire on          |
+| `rerun`             | sub-block (see below)                            | No       | Only valid with `on: userPrompt` + `match: first`  |
+| `cadence`           | sub-block (see below)                            | No       | Only valid with `on: agentResponded`; not with `match: first` |
+| `stopReasons`       | list of strings                                  | No       | Only valid with `on: agentResponded`. Default: `["end_turn"]` |
+| `excludeOrigins`    | list of strings                                  | No       | Only valid with `on: agentResponded`               |
+
+**`match` values:**
+- `first` — fires only on the *first-ever* message in the conversation. This state **persists across session restarts** — if the processor already fired before the session was stopped and resumed, it will not fire again.
+- `all` — fires on every message.
+- `allExceptFirst` — fires on every message *except* the first. _(Note: camelCase only — `all-except-first` is rejected.)_
+
+**`stopReasons` values** (only for `on: agentResponded`):
+
+| Value              | Meaning                                              |
+| ------------------ | ---------------------------------------------------- |
+| `end_turn`          | Agent finished normally (default)                    |
+| `max_tokens`        | Context limit reached                                |
+| `max_turn_requests` | Turn request limit reached                           |
+| `refusal`           | Agent refused to respond                             |
+| `cancelled`         | Turn was cancelled by the user                       |
+
+**`excludeOrigins` values** (only for `on: agentResponded`):
+
+| Origin value      | Meaning                                              |
+| ----------------- | ---------------------------------------------------- |
+| `user`            | Message sent by the user via the UI                  |
+| `queue`           | Message dispatched from the conversation queue       |
+| `periodic-runner` | Message triggered by the periodic runner             |
+| `mcp-send-prompt` | Message sent via the `mitto_conversation_send_prompt` MCP tool |
+
+### Phase/Field Rules
+
+Which fields are allowed or forbidden depends on the `on:` phase:
+
+| Field / Setting                    | `on: userPrompt`      | `on: agentResponded`         |
+| ---------------------------------- | --------------------- | ----------------------------- |
+| `text:`                            | ✅ allowed            | ❌ forbidden                  |
+| `mutate:`                          | ✅ required (text mode) | ❌ forbidden                |
+| `command:`                         | ✅ allowed            | ✅ allowed                    |
+| `prompt:`                          | ✅ allowed            | ✅ allowed                    |
+| `when.rerun:`                      | ✅ allowed (`match: first` only) | ❌ forbidden       |
+| `when.stopReasons:`                | ❌ forbidden          | ✅ allowed (default: `[end_turn]`) |
+| `when.excludeOrigins:`             | ❌ forbidden          | ✅ allowed                    |
+| `output: transform/prepend/append` | ✅ allowed            | ❌ forbidden                  |
+| `output: discard`                  | ✅ allowed            | ✅ allowed                    |
+
+
+
+### Migration Table
+
+If you have existing processors using the old schema, update them as follows:
+
+| Old syntax                                          | New syntax                                          |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `when: first` (scalar)                              | `when:\n  on: userPrompt\n  match: first`           |
+| `when:\n  sent: first`                              | `when:\n  on: userPrompt\n  match: first`           |
+| `when:\n  sent: all`                                | `when:\n  on: userPrompt\n  match: all`             |
+| `when:\n  sent: all-except-first`                   | `when:\n  on: userPrompt\n  match: allExceptFirst`  |
+| `position: prepend` / `position: append`            | `mutate: prepend` / `mutate: append`                |
 
 ### Conditional Enablement
 
@@ -425,16 +523,19 @@ expression must evaluate to `true`.
 
 ### Automatic Re-run (`rerun`)
 
-Processors with `when: first` normally fire only once (on the first message after session
-start or resume). The `rerun` field allows them to fire again periodically, refreshing
-context for the LLM. Thresholds can be based on time, message count, or token usage.
+Processors with `on: userPrompt` and `match: first` normally fire only once (on the first
+message after session start or resume). The `rerun` field allows them to fire again
+periodically, refreshing context for the LLM. Thresholds can be based on time, message
+count, or token usage.
 
 ```yaml
-when: first
-rerun:
-  afterTime: 30m # re-run after 30 minutes since last run
-  afterSentMsgs: 20 # re-run after 20 user messages since last run
-  afterTokens: 50000 # re-run after 50000 tokens consumed since last run
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 30m     # re-run after 30 minutes since last run
+    afterSentMsgs: 20  # re-run after 20 user messages since last run
+    afterTokens: 50000 # re-run after 50000 tokens consumed since last run
 ```
 
 | Field           | Type     | Description                                               |
@@ -443,13 +544,58 @@ rerun:
 | `afterSentMsgs` | int      | Number of user messages sent since last run               |
 | `afterTokens`   | int      | Number of tokens consumed since last run (actual or estimated) |
 
-If both are set, whichever threshold is reached first triggers the re-run.
+If multiple thresholds are set, whichever is reached first triggers the re-run.
 
 Rerun state is tracked **in memory only** — not persisted across restarts. This is
-correct because `isFirstPrompt = true` on session resume already handles the restart case.
+correct because `match: first` on session resume already handles the restart case.
 
-> **Note:** `rerun` is only valid with `when: first`. The loader rejects processors that
-> combine `rerun` with other `when` values.
+> **Note:** `rerun` is only valid with `on: userPrompt` + `match: first`. The loader
+> rejects processors that specify `rerun` with any other combination.
+
+## Cadence Throttling (`cadence`)
+
+`on: agentResponded` processors with `match: all` can fire on every agent response, which
+may be too frequent for expensive background tasks. The `cadence:` block throttles how
+often the processor runs. **All specified thresholds must be met simultaneously (AND).**
+
+```yaml
+when:
+  on: agentResponded
+  match: all
+  cadence:
+    everyNTurns: 3      # fire every 3 agent responses since last firing
+    everyNTokens: 15000 # AND only after 15k cumulative tokens since last firing
+    afterInterval: 5m   # AND only after 5 minutes since last firing
+```
+
+| Field           | Type     | Description                                                       |
+| --------------- | -------- | ----------------------------------------------------------------- |
+| `everyNTurns`   | int      | Fire every N agent responses since the last firing (pre-increment: `everyNTurns: 3` fires on turns 3, 6, 9, …) |
+| `everyNTokens`  | int      | Fire only after N cumulative tokens since the last firing         |
+| `afterInterval` | duration | Fire only after this much wall-clock time since the last firing (`"5m"`, `"1h"`, `"30s"`) |
+
+**Constraints:**
+- Only valid with `on: agentResponded`.
+- Not valid with `match: first` (firing once needs no cadence).
+- At least one field must be specified.
+- All values must be positive.
+
+**Example** — run a preference extractor every 5 turns, but only once 30k tokens have
+accumulated and at most once every 5 minutes:
+
+```yaml
+when:
+  on: agentResponded
+  match: all
+  stopReasons: [end_turn]
+  cadence:
+    everyNTurns: 5
+    everyNTokens: 30000
+    afterInterval: 5m
+```
+
+Cadence state (turn count, token count, last-fired time) is persisted to
+`<session_dir>/processor_state.json` so the counters survive session restarts.
 
 ## Command Resolution (Command-Mode Only)
 
@@ -475,7 +621,9 @@ For processors with companion scripts, use relative paths:
 # git-context.yaml
 name: git-context
 command: ./git-context.sh # Resolved to processors/git-context.sh
-when: first
+when:
+  on: userPrompt
+  match: first
 ```
 
 ## Input Format — Command-Mode (stdin)
@@ -734,7 +882,9 @@ jq -n '{
 
 ```yaml
 name: session-context
-when: first
+when:
+  on: userPrompt
+  match: first
 command: ./session-context.sh
 output: prepend
 ```
@@ -757,7 +907,9 @@ Add recent git commits to the first message:
 # processors/git-context.yaml
 name: git-context
 description: "Adds recent git commits to context"
-when: first
+when:
+  on: userPrompt
+  match: first
 command: ./git-context.sh
 input: message
 output: prepend
@@ -788,7 +940,9 @@ Transform code blocks in messages:
 # processors/format-code.yaml
 name: format-code
 description: "Formats code blocks in messages"
-when: all
+when:
+  on: userPrompt
+  match: all
 command: /usr/local/bin/format-code-blocks
 input: message
 output: transform
@@ -805,7 +959,9 @@ Add project-specific rules for certain workspaces using CEL or workspace-local p
 # processors/project-rules.yaml
 name: project-rules
 description: "Adds project-specific coding rules"
-when: first
+when:
+  on: userPrompt
+  match: first
 command: /bin/cat
 args:
   - "${MITTO_WORKING_DIR}/.ai-rules"
@@ -864,7 +1020,7 @@ Processors that timeout or exit with non-zero status are treated as errors.
 | Dependencies  | None                         | External script or binary              | Workspace with auxiliary ACP server          |
 
 All modes share the same triggering (`when`), priority, conditional enablement
-(`enabledWhen`), re-run, and error handling features. The `position`, `input`, and
+(`enabledWhen`), re-run, and error handling features. The `mutate`, `input`, and
 `output` fields are only applicable to text-mode and command-mode processors.
 
 ## Processor Statistics

--- a/docs/config/user-data.md
+++ b/docs/config/user-data.md
@@ -136,8 +136,10 @@ prompts:
 conversations:
   # Message processing
   processing:
-    - when: first
-      position: prepend
+    - when:
+        on: userPrompt
+        match: first
+      mutate: prepend
       text: |
         This is the MyProject workspace.
         Follow our coding standards.

--- a/docs/config/workspace.md
+++ b/docs/config/workspace.md
@@ -101,8 +101,10 @@ prompts:
 conversations:
   processing:
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: |
           You are working on MyProject, a Node.js application.
           Follow TypeScript strict mode and ESLint rules.

--- a/docs/devel/processors.md
+++ b/docs/devel/processors.md
@@ -1,16 +1,19 @@
 # Message Processing Pipeline
 
-Mitto has a unified message processing pipeline that transforms user messages before sending them to the ACP agent. All processors run **before** the message reaches the agent, and the **original** (untransformed) message is what gets recorded in session history.
+Mitto has a unified message processing pipeline. Processors can run at two points in the conversation lifecycle:
+
+- **`userPrompt` phase** — fires *before* the user's message is sent to the ACP agent. All three modes (text, command, prompt) are valid. The original (untransformed) message is what gets recorded in session history.
+- **`agentResponded` phase** — fires *after* the agent finishes a turn. Only command-mode and prompt-mode are valid. Data-extraction processors (e.g., `identify-user-data`, `memorize-preferences`) run here because they benefit from seeing the agent's reply.
 
 ## Architecture Overview
 
-The pipeline is managed by a single `processors.Manager` that merges three types of processors into a priority-sorted(stable) list:
+The pipeline is managed by a single `processors.Manager` that merges three types of processors into a priority-sorted (stable) list:
 
-1. **Text-mode Processors** (from `config.MessageProcessor`) — Lightweight, declarative text prepend/append rules defined in YAML configuration. These run at priority 0 by default.
-2. **Command-mode Processors** (from `internal/processors/`) — External command-based transformations that can run arbitrary scripts, produce attachments, and fully replace messages. These run at priority 100 by default.
-3. **Prompt-mode Processors** (from `internal/processors/`) — Fire-and-forget prompts dispatched to a workspace-scoped auxiliary AI agent. They do not modify the outgoing message. The prompt template uses standard `@mitto:variable` substitution; the auxiliary agent retrieves conversation history at runtime via the `mitto_conversation_history` MCP tool. These typically run at priority 200.
+1. **Text-mode Processors** (from `config.MessageProcessor`) — Lightweight, declarative text prepend/append rules defined in YAML configuration. Only valid for `on: userPrompt`. Run at priority 0 by default.
+2. **Command-mode Processors** (from `internal/processors/`) — External command-based transformations that can run arbitrary scripts, produce attachments, and fully replace messages. Valid for both phases. Run at priority 100 by default.
+3. **Prompt-mode Processors** (from `internal/processors/`) — Fire-and-forget prompts dispatched to a workspace-scoped auxiliary AI agent. They do not modify the outgoing message. Valid for both phases. Run at priority 200 by default.
 
-All types share the same `when` condition types (`first`, `all`, `all-except-first`) from the `config.ProcessorWhen` type. Text-mode processors from config are merged into the unified pipeline via `Manager.CloneWithTextProcessors()`, which returns a per-session copy to avoid data races on the shared Manager instance.
+All processors use the same `when:` block schema with `on:` (phase) and `match:` fields. Text-mode processors from config are merged into the unified pipeline via `Manager.CloneWithTextProcessors()`, which returns a per-session copy to avoid data races on the shared Manager instance.
 
 ## Processing Flow
 
@@ -67,10 +70,14 @@ conversations:
   processing:
     override: false # true = replace global processors entirely
     processors:
-      - when: first # first | all | all-except-first
-        position: prepend # prepend | append
+      - when:
+          on: userPrompt    # required: userPrompt | agentResponded
+          match: first      # required: first | all | allExceptFirst
+        mutate: prepend     # prepend | append (required for text mode)
         text: "System prompt.\n\n"
 ```
+
+> **Note:** Inline `.mittorc` processors support `on:` and `match:` only — `rerun:`, `stopReasons:`, and `excludeOrigins:` are not available inline. Use standalone YAML processor files for those features.
 
 ### Merge Behavior
 
@@ -93,7 +100,11 @@ Each processor is checked with `ShouldApply(isFirstMessage)` and applied with `A
 
 | Type                     | Package           | Purpose                                     |
 | ------------------------ | ----------------- | ------------------------------------------- |
-| `MessageProcessor`       | `internal/config` | Single prepend/append rule                  |
+| `MessageProcessor`       | `internal/config` | Single prepend/append rule (inline `.mittorc`) |
+| `ProcessorPhase`         | `internal/config` | Phase enum: `"userPrompt"` / `"agentResponded"` |
+| `ProcessorMatch`         | `internal/config` | Match enum: `"first"` / `"all"` / `"allExceptFirst"` |
+| `ProcessorMutate`        | `internal/config` | Mutate enum: `"prepend"` / `"append"` |
+| `ProcessorWhenBlock`     | `internal/config` | `when:` block for inline processors (On + Match only) |
 | `ConversationProcessing` | `internal/config` | Processor list + override flag              |
 | `ConversationsConfig`    | `internal/config` | Top-level config (processors + queue + ...) |
 
@@ -108,15 +119,17 @@ Command processors are YAML files in `MITTO_DIR/processors/*.yaml` (typically `~
 ```yaml
 name: code-context
 description: Adds project context from a script
-when: first
+when:
+  on: userPrompt    # userPrompt | agentResponded
+  match: first      # first | all | allExceptFirst
 command: ./gather-context.sh
-input: message # message | conversation | none
-output: prepend # transform | prepend | append | discard
-priority: 50 # Lower = runs first (default: 100)
+input: message      # message | conversation | none
+output: prepend     # transform | prepend | append | discard
+priority: 50        # Lower = runs first (default: 100)
 timeout: 5s
 working_dir: session # session | hook
-on_error: skip # skip | fail
-workspaces: # Optional: limit to specific projects
+on_error: skip      # skip | fail
+workspaces:         # Optional: limit to specific projects
   - /path/to/project
 ```
 
@@ -239,7 +252,9 @@ With its processor YAML (`MITTO_DIR/processors/gather-context.yaml`):
 ```yaml
 name: gather-context
 description: Adds project and branch info on the first message
-when: first
+when:
+  on: userPrompt
+  match: first
 command: ./gather-context.sh
 output: prepend
 priority: 10
@@ -260,14 +275,141 @@ source "$MITTO_PROCESSOR_DIR/helpers.sh"
 | Type              | File             | Purpose                                   |
 | ----------------- | ---------------- | ----------------------------------------- |
 | `Processor`       | `types.go`       | Processor definition (parsed from YAML)   |
+| `Phase`           | `types.go`       | Phase enum (`PhaseUserPrompt`, `PhaseAgentResponded`) |
+| `Match`           | `types.go`       | Match enum (`MatchFirst`, `MatchAll`, `MatchAllExceptFirst`) |
+| `WhenConfig`      | `types.go`       | `when:` block (On, Match, Rerun, Cadence, StopReasons, ExcludeOrigins) |
+| `RerunConfig`     | `types.go`       | Rerun thresholds (AfterTime, AfterSentMsgs, AfterTokens) |
+| `CadenceConfig`   | `types.go`       | Cadence thresholds (EveryNTurns, EveryNTokens, AfterInterval) |
+| `ProcessorStateData` | `state.go`    | Persisted state (AgentResponseCount + per-processor cadence map) |
+| `ProcessorCadenceState` | `state.go` | Per-processor cadence state (TurnsSinceLastFire, TokensSinceLastFire, LastFiredAt) |
+| `StateStore`      | `state.go`       | Interface: Load/Save ProcessorStateData by session dir |
+| `FileStateStore`  | `state.go`       | Prod implementation: atomic JSON writes to `processor_state.json` |
+| `MemoryStateStore`| `state.go`       | Test implementation: in-memory map |
 | `ProcessorSource` | `types.go`       | Source enum: `global`, `builtin`, `workspace`, `config` |
 | `Manager`         | `apply.go`       | High-level load + apply interface         |
-| `Loader`          | `loader.go`      | Discovers and parses processor YAML files |
+| `Loader`          | `loader.go`      | Discovers, parses, and validates processor YAML files |
 | `Executor`        | `executor.go`    | Runs a single processor as subprocess     |
 | `ProcessorInput`  | `input.go`       | Context sent to processor stdin           |
 | `ProcessorOutput` | `input.go`       | Parsed result from processor stdout       |
 | `Attachment`      | `input.go`       | File attachment from processor            |
 | `WebProcessor`    | `session_api.go` | API response type for workspace processors endpoint |
+
+## Validation Rules (`internal/processors/loader.go`)
+
+The loader enforces 16 strict rules. Processors that fail any rule are skipped with a WARN log.
+
+| # | Rule                                                                                 |
+|---|--------------------------------------------------------------------------------------|
+| 1 | `when.on` is required — must be `"userPrompt"` or `"agentResponded"`                |
+| 2 | `when.match` is required — must be `"first"`, `"all"`, or `"allExceptFirst"`        |
+| 3 | `when.match: "all-except-first"` (kebab-case) is explicitly rejected                |
+| 4 | `on: agentResponded` forbids `text:` (text mode not meaningful post-response)        |
+| 5 | `on: agentResponded` forbids `mutate:`                                               |
+| 6 | `on: agentResponded` forbids `when.rerun:`                                           |
+| 7 | `on: agentResponded` forbids `output: transform/prepend/append`                     |
+| 8 | `on: agentResponded` defaults `stopReasons` to `["end_turn"]` if not specified       |
+| 9 | `on: userPrompt` forbids `when.stopReasons:`                                         |
+| 10| `on: userPrompt` forbids `when.excludeOrigins:`                                     |
+| 11| Text-mode processors (`text:` set, `command:` empty) require `mutate: prepend` or `mutate: append` |
+| 12| `when.cadence` is only valid with `on: agentResponded`                               |
+| 13| `when.cadence` is not valid with `match: first` (firing once needs no cadence)       |
+| 14| `when.cadence` requires at least one threshold field to be set                       |
+| 15| `when.cadence.everyNTurns` and `when.cadence.everyNTokens` must be non-negative      |
+| 16| `when.cadence.afterInterval` must be a parseable Go duration string (e.g. `"5m"`)    |
+
+Additionally, `when.rerun:` is only allowed with `match: first` — combining with `match: all` or `match: allExceptFirst` is rejected.
+
+## Cadence and Persisted State
+
+`on: agentResponded` processors with `match: all` can use the `cadence:` block to throttle
+how frequently they fire. All specified thresholds are evaluated with AND logic — every
+specified threshold must be met simultaneously.
+
+### `CadenceConfig` struct (`internal/processors/types.go`)
+
+```go
+type CadenceConfig struct {
+    EveryNTurns  int    // fire every N agent responses since last firing
+    EveryNTokens int    // AND: only after N cumulative tokens since last firing
+    AfterInterval string // AND: only after this wall-clock duration since last firing
+}
+```
+
+`GetAfterIntervalDuration()` parses `AfterInterval` via `time.ParseDuration`.
+
+### Pre-increment semantics
+
+The turn counter is incremented **before** the gate check, so `everyNTurns: 3` fires on
+agent responses 3, 6, 9, … (every 3rd response), not 4, 7, 10, … This is the most
+intuitive interpretation of "every N turns".
+
+### `StateStore` interface (`internal/processors/state.go`)
+
+```go
+type StateStore interface {
+    Load(sessionDir string) (*ProcessorStateData, error)
+    Save(sessionDir string, state *ProcessorStateData) error
+}
+```
+
+| Implementation    | Used when          | Behavior                                         |
+| ----------------- | ------------------ | ------------------------------------------------ |
+| `FileStateStore`  | Production         | Reads/writes `<session_dir>/processor_state.json` via `fileutil.WriteJSONAtomic` |
+| `MemoryStateStore`| Tests              | In-memory map keyed by `sessionDir`; never hits disk |
+
+### Persisted state shape (`ProcessorStateData`)
+
+```go
+type ProcessorStateData struct {
+    AgentResponseCount int                          // global response counter
+    Processors         map[string]*ProcessorCadenceState // per-processor cadence state
+}
+
+type ProcessorCadenceState struct {
+    TurnsSinceLastFire  int       // how many turns since this processor last fired
+    TokensSinceLastFire int       // cumulative tokens since last firing
+    LastFiredAt         time.Time // wall-clock time of last firing (zero = never)
+}
+```
+
+State file location: `<session_dir>/processor_state.json`
+(e.g., `~/Library/Application Support/Mitto/sessions/{id}/processor_state.json`)
+
+### Q1 resolution: `match: first` across session restarts
+
+The old in-memory `agentResponseCount` on `Manager` was replaced by the persisted
+`AgentResponseCount` field in `ProcessorStateData`. On session resume, `ApplyAfter`
+loads the state file and checks whether `AgentResponseCount > 0` — if so, the processor
+has already fired and `match: first` is honoured correctly across restarts.
+
+### Clock injection for tests
+
+`Manager` exposes `SetClock(func() time.Time)` to allow deterministic time-based testing:
+
+```go
+fakeNow := time.Now()
+mgr.SetClock(func() time.Time { return fakeNow })
+// Advance time in tests:
+fakeNow = fakeNow.Add(10 * time.Minute)
+```
+
+### Crash safety
+
+State is saved at the **end** of `ApplyAfter`. A crash mid-flight may lose one turn
+increment, which is acceptable — the cadence will fire one turn later at worst. Atomic
+writes via `fileutil.WriteJSONAtomic` prevent partial writes from corrupting the file.
+
+## Two-Phase Architecture
+
+```mermaid
+flowchart TD
+    Prompt[User sends prompt] --> PhaseA[Phase: userPrompt\nText / Command / Prompt processors]
+    PhaseA --> ACP[ACP Agent responds]
+    ACP --> PhaseB[Phase: agentResponded\nCommand / Prompt processors only]
+    PhaseB --> Done[Turn complete]
+
+    style PhaseB stroke-dasharray: 5 5
+```
 
 ## Variable Substitution
 
@@ -362,8 +504,10 @@ A declarative processor in `.mittorc`:
 conversations:
   processing:
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "Session: @mitto:session_id\nProject: @mitto:working_dir\n\n"
 ```
 

--- a/internal/cmd/processors.go
+++ b/internal/cmd/processors.go
@@ -25,7 +25,8 @@ Example processor file (processors/git-context.yaml):
 
   name: git-context
   description: "Adds recent git commits to context"
-  when: first
+  when:
+    sent: first
   command: ./git-context.sh
   input: message
   output: prepend`,
@@ -111,8 +112,8 @@ func runProcessorsList(cmd *cobra.Command, args []string) error {
 
 	// Use tabwriter for aligned output
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tDESCRIPTION\tPRIORITY\tWHEN\tFILE")
-	fmt.Fprintln(w, "----\t-----------\t--------\t----\t----")
+	fmt.Fprintln(w, "NAME\tDESCRIPTION\tPRIORITY\tON\tMATCH\tFILE")
+	fmt.Fprintln(w, "----\t-----------\t--------\t--\t-----\t----")
 
 	for _, p := range procs {
 		desc := p.Description
@@ -122,7 +123,7 @@ func runProcessorsList(cmd *cobra.Command, args []string) error {
 		if len(desc) > 40 {
 			desc = desc[:37] + "..."
 		}
-		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", p.Name, desc, p.GetPriority(), p.When, filepath.Base(p.FilePath))
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n", p.Name, desc, p.GetPriority(), p.When.On, p.When.Match, filepath.Base(p.FilePath))
 	}
 	w.Flush()
 

--- a/internal/cmd/processors.go
+++ b/internal/cmd/processors.go
@@ -26,7 +26,8 @@ Example processor file (processors/git-context.yaml):
   name: git-context
   description: "Adds recent git commits to context"
   when:
-    sent: first
+    on: userPrompt
+    match: first
   command: ./git-context.sh
   input: message
   output: prepend`,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -421,11 +421,15 @@ func (c *WebConfig) GetAPIPrefix() string {
 //	conversations:
 //	  processing:
 //	    processors:
-//	      - when: first
-//	        position: prepend
+//	      - when:
+//	          on:    userPrompt
+//	          match: first
+//	        mutate: prepend
 //	        text: "You are a helpful assistant.\n\n"
-//	      - when: all
-//	        position: append
+//	      - when:
+//	          on:    userPrompt
+//	          match: all
+//	        mutate: append
 //	        text: "\n\n[Be concise]"
 //
 // Example usage in code:
@@ -434,41 +438,81 @@ func (c *WebConfig) GetAPIPrefix() string {
 //	procMgr.AddTextProcessors(procs, 0) // priority 0 → runs before command-mode processors
 // ============================================================================
 
-// ProcessorWhen defines when a message processor should be applied.
-// Valid values: "first", "all", "all-except-first"
-type ProcessorWhen string
+// ProcessorPhase defines when in the conversation lifecycle a processor fires.
+// Valid values: "userPrompt", "agentResponded"
+type ProcessorPhase string
 
 const (
-	// ProcessorWhenFirst applies only to the first message in a conversation.
-	// Use this for initial context or system prompts.
-	ProcessorWhenFirst ProcessorWhen = "first"
-	// ProcessorWhenAll applies to all messages in the conversation.
-	// Use this for reminders or constraints that should always be present.
-	ProcessorWhenAll ProcessorWhen = "all"
-	// ProcessorWhenAllExceptFirst applies to all messages except the first.
-	// Use this for continuation markers or follow-up context.
-	ProcessorWhenAllExceptFirst ProcessorWhen = "all-except-first"
+	// ProcessorPhaseUserPrompt fires processors before the user's message is sent to the agent.
+	ProcessorPhaseUserPrompt ProcessorPhase = "userPrompt"
+	// ProcessorPhaseAgentResponded fires processors after the agent has finished responding.
+	ProcessorPhaseAgentResponded ProcessorPhase = "agentResponded"
 )
 
-// ProcessorPosition defines where the processor text is inserted relative to the message.
+// ProcessorMatch defines which messages in the sequence a processor applies to.
+// Valid values: "first", "all", "allExceptFirst"
+type ProcessorMatch string
+
+const (
+	// ProcessorMatchFirst applies only to the first-ever message in a conversation.
+	ProcessorMatchFirst ProcessorMatch = "first"
+	// ProcessorMatchAll applies to every message.
+	ProcessorMatchAll ProcessorMatch = "all"
+	// ProcessorMatchAllExceptFirst applies to all messages except the first.
+	ProcessorMatchAllExceptFirst ProcessorMatch = "allExceptFirst"
+)
+
+// ProcessorMutate defines where the processor text is inserted relative to the message.
 // Valid values: "prepend", "append"
-type ProcessorPosition string
+type ProcessorMutate string
 
 const (
-	// ProcessorPositionPrepend inserts text before the user's message.
-	ProcessorPositionPrepend ProcessorPosition = "prepend"
-	// ProcessorPositionAppend inserts text after the user's message.
-	ProcessorPositionAppend ProcessorPosition = "append"
+	// ProcessorMutatePrepend inserts text before the user's message.
+	ProcessorMutatePrepend ProcessorMutate = "prepend"
+	// ProcessorMutateAppend inserts text after the user's message.
+	ProcessorMutateAppend ProcessorMutate = "append"
 )
+
+// ProcessorWhenBlock is the block form of the when condition used in inline .mittorc processors.
+// Inline processors support on: and match: only — no rerun, stopReasons, or excludeOrigins.
+//
+//	when:
+//	  on:    userPrompt | agentResponded
+//	  match: first | all | allExceptFirst
+type ProcessorWhenBlock struct {
+	On    ProcessorPhase `yaml:"on" json:"on"`
+	Match ProcessorMatch `yaml:"match" json:"match"`
+}
+
+// UnmarshalYAML enforces the block form for `when` in inline .mittorc processors.
+// The scalar form (`when: first`) and the old `sent:` key are rejected.
+func (w *ProcessorWhenBlock) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		return fmt.Errorf("processor 'when' must be a block (got scalar %q); use:\n  when:\n    on: userPrompt\n    match: %s", value.Value, value.Value)
+	}
+	// Check for legacy `sent:` key and provide a clear migration message.
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i].Value == "sent" {
+			return fmt.Errorf("processor 'when.sent' is no longer supported; replace with 'on:' + 'match:' (e.g., on: userPrompt, match: %s)", value.Content[i+1].Value)
+		}
+	}
+	type rawBlock ProcessorWhenBlock // avoid infinite recursion
+	var raw rawBlock
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*w = ProcessorWhenBlock(raw)
+	return nil
+}
 
 // MessageProcessor defines a single message transformation rule.
 // Processors are applied in order to transform user messages before sending to the ACP server.
 // Each processor specifies when it applies, where to insert text, and what text to insert.
 type MessageProcessor struct {
-	// When specifies when this processor applies: "first", "all", or "all-except-first"
-	When ProcessorWhen `json:"when" yaml:"when"`
-	// Position specifies where to insert the text: "prepend" (before) or "append" (after)
-	Position ProcessorPosition `json:"position" yaml:"position"`
+	// When specifies when this processor applies.
+	When ProcessorWhenBlock `json:"when" yaml:"when"`
+	// Mutate specifies where to insert the text: "prepend" (before) or "append" (after)
+	Mutate ProcessorMutate `json:"mutate" yaml:"mutate"`
 	// Text is the content to insert at the specified position
 	Text string `json:"text" yaml:"text"`
 }
@@ -1108,9 +1152,9 @@ type rawConfig struct {
 		Processing *struct {
 			Override   bool `yaml:"override"`
 			Processors []struct {
-				When     string `yaml:"when"`
-				Position string `yaml:"position"`
-				Text     string `yaml:"text"`
+				When   ProcessorWhenBlock `yaml:"when"`
+				Mutate string             `yaml:"mutate"`
+				Text   string             `yaml:"text"`
 			} `yaml:"processors"`
 		} `yaml:"processing"`
 		Queue *struct {
@@ -1372,9 +1416,9 @@ func Parse(data []byte) (*Config, error) {
 			processors := make([]MessageProcessor, 0, len(raw.Conversations.Processing.Processors))
 			for _, p := range raw.Conversations.Processing.Processors {
 				processors = append(processors, MessageProcessor{
-					When:     ProcessorWhen(p.When),
-					Position: ProcessorPosition(p.Position),
-					Text:     p.Text,
+					When:   p.When,
+					Mutate: ProcessorMutate(p.Mutate),
+					Text:   p.Text,
 				})
 			}
 			if len(processors) > 0 || raw.Conversations.Processing.Override {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1513,15 +1513,18 @@ func boolPtr(b bool) *bool {
 func TestMessageProcessor_Fields(t *testing.T) {
 	// Verify the struct fields are correct (used for config parsing).
 	p := &MessageProcessor{
-		When:     ProcessorWhenFirst,
-		Position: ProcessorPositionPrepend,
-		Text:     "hello",
+		When:   ProcessorWhenBlock{On: ProcessorPhaseUserPrompt, Match: ProcessorMatchFirst},
+		Mutate: ProcessorMutatePrepend,
+		Text:   "hello",
 	}
-	if p.When != ProcessorWhenFirst {
-		t.Errorf("When = %q, want %q", p.When, ProcessorWhenFirst)
+	if p.When.On != ProcessorPhaseUserPrompt {
+		t.Errorf("When.On = %q, want %q", p.When.On, ProcessorPhaseUserPrompt)
 	}
-	if p.Position != ProcessorPositionPrepend {
-		t.Errorf("Position = %q, want %q", p.Position, ProcessorPositionPrepend)
+	if p.When.Match != ProcessorMatchFirst {
+		t.Errorf("When.Match = %q, want %q", p.When.Match, ProcessorMatchFirst)
+	}
+	if p.Mutate != ProcessorMutatePrepend {
+		t.Errorf("Mutate = %q, want %q", p.Mutate, ProcessorMutatePrepend)
 	}
 	if p.Text != "hello" {
 		t.Errorf("Text = %q, want %q", p.Text, "hello")
@@ -1530,10 +1533,10 @@ func TestMessageProcessor_Fields(t *testing.T) {
 
 func TestMergeProcessors(t *testing.T) {
 	globalProcessors := []MessageProcessor{
-		{When: ProcessorWhenAll, Position: ProcessorPositionAppend, Text: ":GLOBAL"},
+		{When: ProcessorWhenBlock{On: ProcessorPhaseUserPrompt, Match: ProcessorMatchAll}, Mutate: ProcessorMutateAppend, Text: ":GLOBAL"},
 	}
 	workspaceProcessors := []MessageProcessor{
-		{When: ProcessorWhenFirst, Position: ProcessorPositionPrepend, Text: "WORKSPACE:"},
+		{When: ProcessorWhenBlock{On: ProcessorPhaseUserPrompt, Match: ProcessorMatchFirst}, Mutate: ProcessorMutatePrepend, Text: "WORKSPACE:"},
 	}
 
 	global := &ConversationsConfig{
@@ -1558,10 +1561,10 @@ func TestMergeProcessors(t *testing.T) {
 
 func TestMergeProcessors_Override(t *testing.T) {
 	globalProcessors := []MessageProcessor{
-		{When: ProcessorWhenAll, Position: ProcessorPositionAppend, Text: ":GLOBAL"},
+		{When: ProcessorWhenBlock{On: ProcessorPhaseUserPrompt, Match: ProcessorMatchAll}, Mutate: ProcessorMutateAppend, Text: ":GLOBAL"},
 	}
 	workspaceProcessors := []MessageProcessor{
-		{When: ProcessorWhenFirst, Position: ProcessorPositionPrepend, Text: "WORKSPACE:"},
+		{When: ProcessorWhenBlock{On: ProcessorPhaseUserPrompt, Match: ProcessorMatchFirst}, Mutate: ProcessorMutatePrepend, Text: "WORKSPACE:"},
 	}
 
 	global := &ConversationsConfig{
@@ -1623,11 +1626,15 @@ conversations:
   processing:
     override: false
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "System prompt\n\n"
-      - when: all
-        position: append
+      - when:
+          on: userPrompt
+          match: all
+        mutate: append
         text: "\n\n[Be concise]"
 `
 	cfg, err := Parse([]byte(yaml))
@@ -1649,22 +1656,28 @@ conversations:
 	}
 
 	p0 := cfg.Conversations.Processing.Processors[0]
-	if p0.When != ProcessorWhenFirst {
-		t.Errorf("Processor[0].When = %q, want %q", p0.When, ProcessorWhenFirst)
+	if p0.When.On != ProcessorPhaseUserPrompt {
+		t.Errorf("Processor[0].When.On = %q, want %q", p0.When.On, ProcessorPhaseUserPrompt)
 	}
-	if p0.Position != ProcessorPositionPrepend {
-		t.Errorf("Processor[0].Position = %q, want %q", p0.Position, ProcessorPositionPrepend)
+	if p0.When.Match != ProcessorMatchFirst {
+		t.Errorf("Processor[0].When.Match = %q, want %q", p0.When.Match, ProcessorMatchFirst)
+	}
+	if p0.Mutate != ProcessorMutatePrepend {
+		t.Errorf("Processor[0].Mutate = %q, want %q", p0.Mutate, ProcessorMutatePrepend)
 	}
 	if p0.Text != "System prompt\n\n" {
 		t.Errorf("Processor[0].Text = %q, want %q", p0.Text, "System prompt\n\n")
 	}
 
 	p1 := cfg.Conversations.Processing.Processors[1]
-	if p1.When != ProcessorWhenAll {
-		t.Errorf("Processor[1].When = %q, want %q", p1.When, ProcessorWhenAll)
+	if p1.When.On != ProcessorPhaseUserPrompt {
+		t.Errorf("Processor[1].When.On = %q, want %q", p1.When.On, ProcessorPhaseUserPrompt)
 	}
-	if p1.Position != ProcessorPositionAppend {
-		t.Errorf("Processor[1].Position = %q, want %q", p1.Position, ProcessorPositionAppend)
+	if p1.When.Match != ProcessorMatchAll {
+		t.Errorf("Processor[1].When.Match = %q, want %q", p1.When.Match, ProcessorMatchAll)
+	}
+	if p1.Mutate != ProcessorMutateAppend {
+		t.Errorf("Processor[1].Mutate = %q, want %q", p1.Mutate, ProcessorMutateAppend)
 	}
 }
 

--- a/internal/config/workspace_rc.go
+++ b/internal/config/workspace_rc.go
@@ -110,9 +110,9 @@ type rawWorkspaceRC struct {
 		Processing *struct {
 			Override   bool `yaml:"override"`
 			Processors []struct {
-				When     string `yaml:"when"`
-				Position string `yaml:"position"`
-				Text     string `yaml:"text"`
+				When   ProcessorWhenBlock `yaml:"when"`
+				Mutate string             `yaml:"mutate"`
+				Text   string             `yaml:"text"`
 			} `yaml:"processors"`
 		} `yaml:"processing"`
 		// UserData defines the schema for custom user data attributes (legacy location)
@@ -696,9 +696,9 @@ func parseWorkspaceRC(data []byte) (*WorkspaceRC, error) {
 		processors := make([]MessageProcessor, 0, len(raw.Conversations.Processing.Processors))
 		for _, p := range raw.Conversations.Processing.Processors {
 			processors = append(processors, MessageProcessor{
-				When:     ProcessorWhen(p.When),
-				Position: ProcessorPosition(p.Position),
-				Text:     p.Text,
+				When:   p.When,
+				Mutate: ProcessorMutate(p.Mutate),
+				Text:   p.Text,
 			})
 		}
 		if len(processors) > 0 || raw.Conversations.Processing.Override {

--- a/internal/config/workspace_rc_test.go
+++ b/internal/config/workspace_rc_test.go
@@ -492,11 +492,15 @@ conversations:
   processing:
     override: false
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "System context\n\n"
-      - when: all
-        position: append
+      - when:
+          on: userPrompt
+          match: all
+        mutate: append
         text: "\n\n[Be concise]"
 `
 	rc, err := parseWorkspaceRC([]byte(yaml))
@@ -528,22 +532,28 @@ conversations:
 	}
 
 	p0 := rc.Conversations.Processing.Processors[0]
-	if p0.When != ProcessorWhenFirst {
-		t.Errorf("Processor[0].When = %q, want %q", p0.When, ProcessorWhenFirst)
+	if p0.When.On != ProcessorPhaseUserPrompt {
+		t.Errorf("Processor[0].When.On = %q, want %q", p0.When.On, ProcessorPhaseUserPrompt)
 	}
-	if p0.Position != ProcessorPositionPrepend {
-		t.Errorf("Processor[0].Position = %q, want %q", p0.Position, ProcessorPositionPrepend)
+	if p0.When.Match != ProcessorMatchFirst {
+		t.Errorf("Processor[0].When.Match = %q, want %q", p0.When.Match, ProcessorMatchFirst)
+	}
+	if p0.Mutate != ProcessorMutatePrepend {
+		t.Errorf("Processor[0].Mutate = %q, want %q", p0.Mutate, ProcessorMutatePrepend)
 	}
 	if p0.Text != "System context\n\n" {
 		t.Errorf("Processor[0].Text = %q, want %q", p0.Text, "System context\n\n")
 	}
 
 	p1 := rc.Conversations.Processing.Processors[1]
-	if p1.When != ProcessorWhenAll {
-		t.Errorf("Processor[1].When = %q, want %q", p1.When, ProcessorWhenAll)
+	if p1.When.On != ProcessorPhaseUserPrompt {
+		t.Errorf("Processor[1].When.On = %q, want %q", p1.When.On, ProcessorPhaseUserPrompt)
 	}
-	if p1.Position != ProcessorPositionAppend {
-		t.Errorf("Processor[1].Position = %q, want %q", p1.Position, ProcessorPositionAppend)
+	if p1.When.Match != ProcessorMatchAll {
+		t.Errorf("Processor[1].When.Match = %q, want %q", p1.When.Match, ProcessorMatchAll)
+	}
+	if p1.Mutate != ProcessorMutateAppend {
+		t.Errorf("Processor[1].Mutate = %q, want %q", p1.Mutate, ProcessorMutateAppend)
 	}
 }
 
@@ -553,8 +563,10 @@ conversations:
   processing:
     override: true
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "Override only"
 `
 	rc, err := parseWorkspaceRC([]byte(yaml))
@@ -604,8 +616,10 @@ prompts:
 conversations:
   processing:
     processors:
-      - when: first
-        position: prepend
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "Project context: This is a test project.\n\n"
 `
 	rcPath := filepath.Join(tmpDir, WorkspaceRCFileName)
@@ -775,8 +789,10 @@ func TestParseWorkspaceRC_UserDataSchemaWithProcessors(t *testing.T) {
 conversations:
   processing:
     processors:
-      - when: first
-        position: before
+      - when:
+          on: userPrompt
+          match: first
+        mutate: prepend
         text: "System context"
 metadata:
   user_data:

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -3424,7 +3424,7 @@ func (s *Server) handleConversationUpdate(ctx context.Context, req *mcp.CallTool
 				enabled = input.PeriodicEnabled
 			}
 
-			if err := periodicStore.Update(prompt, freq, enabled); err != nil {
+			if err := periodicStore.Update(prompt, nil, freq, enabled); err != nil {
 				return nil, ConversationUpdateOutput{
 					Success: false,
 					Error:   fmt.Sprintf("failed to update periodic: %v", err),

--- a/internal/processors/after_executor.go
+++ b/internal/processors/after_executor.go
@@ -52,12 +52,15 @@ func executeAfterCommand(ctx context.Context, proc *Processor, processorsDir str
 	duration := time.Since(start)
 
 	if logger != nil {
-		logger.Info("after-phase processor executed",
+		logAttrs := []any{
 			"name", proc.Name,
 			"duration", duration,
-			"exit_code", cmd.ProcessState.ExitCode(),
 			"stderr", stderr.String(),
-		)
+		}
+		if cmd.ProcessState != nil {
+			logAttrs = append(logAttrs, "exit_code", cmd.ProcessState.ExitCode())
+		}
+		logger.Info("after-phase processor executed", logAttrs...)
 	}
 
 	if err != nil {

--- a/internal/processors/after_executor.go
+++ b/internal/processors/after_executor.go
@@ -1,0 +1,205 @@
+package processors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// executeAfterCommand runs a command-mode processor in the agentResponded phase.
+// It marshals the AfterProcessorInput as JSON to stdin, captures stdout, and
+// returns the raw stdout string. Timeout is taken from proc.GetTimeout().
+func executeAfterCommand(ctx context.Context, proc *Processor, processorsDir string, input AfterProcessorInput, logger *slog.Logger) (string, error) {
+	timeout := proc.GetTimeout().Duration()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmdPath := proc.ResolveCommand()
+	cmd := exec.CommandContext(ctx, cmdPath, proc.Args...)
+
+	switch proc.GetWorkingDir() {
+	case WorkingDirSession:
+		if input.WorkingDir != "" {
+			cmd.Dir = input.WorkingDir
+		}
+	case WorkingDirHook:
+		cmd.Dir = proc.HookDir
+	}
+
+	cmd.Env = buildAfterEnvironment(proc, processorsDir, input)
+
+	if proc.GetInput() != InputNone {
+		data, err := json.Marshal(input)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal after-phase input: %w", err)
+		}
+		cmd.Stdin = bytes.NewReader(data)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	if logger != nil {
+		logger.Info("after-phase processor executed",
+			"name", proc.Name,
+			"duration", duration,
+			"exit_code", cmd.ProcessState.ExitCode(),
+			"stderr", stderr.String(),
+		)
+	}
+
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("processor timed out after %v", timeout)
+		}
+		return "", fmt.Errorf("processor failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// executeAfterPrompt handles prompt-mode processors in the agentResponded phase.
+// The prompt template is rendered with after-phase variable substitution, and the
+// rendered text is treated as the stdout payload (parsed per output: type).
+func executeAfterPrompt(proc *Processor, input AfterProcessorInput) (string, error) {
+	rendered := substituteAfterVariables(proc.Prompt, input)
+	return rendered, nil
+}
+
+// substituteAfterVariables replaces @mitto: placeholders for the agentResponded phase.
+func substituteAfterVariables(template string, input AfterProcessorInput) string {
+	if !strings.Contains(template, "@mitto:") {
+		return template
+	}
+
+	turnJSON, _ := json.Marshal(input)
+	agentMessages := strings.Join(input.AgentMessages, "\n")
+
+	replacements := map[string]string{
+		"@mitto:turn":           string(turnJSON),
+		"@mitto:agent_messages": agentMessages,
+		"@mitto:user_prompt":    input.UserPrompt,
+		"@mitto:stop_reason":    input.StopReason,
+		"@mitto:origin":         input.Origin,
+		"@mitto:session_id":     input.SessionID,
+	}
+
+	keys := make([]string, 0, len(replacements))
+	for k := range replacements {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return len(keys[i]) > len(keys[j]) })
+
+	result := template
+	for _, placeholder := range keys {
+		if strings.Contains(result, placeholder) {
+			result = strings.ReplaceAll(result, placeholder, replacements[placeholder])
+		}
+	}
+	return result
+}
+
+// parseNotifyOutput parses processor stdout for output: notify.
+// Accepts:
+//   - JSON object: {"title": "...", "message": "...", "style": "info|success|warning|error"}
+//   - Plain text: first line = title, rest = message, style defaults to "info"
+func parseNotifyOutput(stdout string) ([]AfterNotification, error) {
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return nil, nil
+	}
+	var notif AfterNotification
+	if err := json.Unmarshal([]byte(stdout), &notif); err == nil && notif.Title != "" {
+		if notif.Style == "" {
+			notif.Style = "info"
+		}
+		return []AfterNotification{notif}, nil
+	}
+	lines := strings.SplitN(stdout, "\n", 2)
+	title := strings.TrimSpace(lines[0])
+	message := ""
+	if len(lines) > 1 {
+		message = strings.TrimSpace(lines[1])
+	}
+	return []AfterNotification{{Title: title, Message: message, Style: "info"}}, nil
+}
+
+// parseActionButtonsOutput parses processor stdout for output: actionButtons.
+// Accepts:
+//   - JSON array:  [{"label": "...", "prompt": "..."}, ...]
+//   - JSON object: {"label": "...", "prompt": "..."}  — treated as single-element array
+//   - Empty/blank — returns nil (no buttons)
+func parseActionButtonsOutput(stdout string) ([]AfterActionButton, error) {
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return nil, nil
+	}
+	var buttons []AfterActionButton
+	if err := json.Unmarshal([]byte(stdout), &buttons); err == nil {
+		return buttons, nil
+	}
+	var button AfterActionButton
+	if err := json.Unmarshal([]byte(stdout), &button); err == nil && button.Label != "" {
+		return []AfterActionButton{button}, nil
+	}
+	return nil, fmt.Errorf("invalid actionButtons output: expected JSON array or object, got: %s", afterTruncate(stdout, 100))
+}
+
+// parseUserDataOutput parses processor stdout for output: userData.
+// Expects a JSON object of string → string entries.
+func parseUserDataOutput(stdout string) (map[string]string, error) {
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return nil, nil
+	}
+	var patch map[string]string
+	if err := json.Unmarshal([]byte(stdout), &patch); err != nil {
+		return nil, fmt.Errorf("invalid userData output: expected JSON object of string→string: %w", err)
+	}
+	return patch, nil
+}
+
+// afterTruncate truncates s to at most max bytes, appending "..." if truncated.
+func afterTruncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// buildAfterEnvironment creates environment variables for an agentResponded processor.
+func buildAfterEnvironment(proc *Processor, processorsDir string, input AfterProcessorInput) []string {
+	env := os.Environ()
+
+	mittoEnv := map[string]string{
+		"MITTO_SESSION_ID":     input.SessionID,
+		"MITTO_WORKING_DIR":    input.WorkingDir,
+		"MITTO_PROCESSORS_DIR": processorsDir,
+		"MITTO_PROCESSOR_FILE": proc.FilePath,
+		"MITTO_PROCESSOR_DIR":  proc.HookDir,
+		"MITTO_HOOKS_DIR":      processorsDir, // legacy alias
+		"MITTO_HOOK_FILE":      proc.FilePath, // legacy alias
+		"MITTO_HOOK_DIR":       proc.HookDir,  // legacy alias
+		"MITTO_ORIGIN":         input.Origin,
+		"MITTO_STOP_REASON":    input.StopReason,
+	}
+	for k, v := range mittoEnv {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range proc.Environment {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}

--- a/internal/processors/apply.go
+++ b/internal/processors/apply.go
@@ -71,7 +71,8 @@ func ApplyProcessors(ctx context.Context, procs []*Processor, input *ProcessorIn
 			logger.Debug("processor skipped",
 				"name", proc.Name,
 				"reason", string(skipReason),
-				"when", proc.When,
+				"on", proc.When.On,
+				"match", proc.When.Match,
 				"priority", proc.GetPriority(),
 			)
 			continue
@@ -81,23 +82,24 @@ func ApplyProcessors(ctx context.Context, procs []*Processor, input *ProcessorIn
 		result.AppliedNames = append(result.AppliedNames, proc.Name)
 		logger.Info("applying processor",
 			"name", proc.Name,
-			"when", proc.When,
+			"on", proc.When.On,
+			"match", proc.When.Match,
 			"mode", map[bool]string{true: "text", false: "command"}[proc.IsTextMode()],
-			"position", proc.GetPosition(),
+			"mutate", proc.GetMutate(),
 			"priority", proc.GetPriority(),
 		)
 
 		// Text-mode: directly prepend or append the static text (no external command).
 		if proc.IsTextMode() {
-			switch proc.GetPosition() {
-			case config.ProcessorPositionPrepend:
+			switch proc.GetMutate() {
+			case config.ProcessorMutatePrepend:
 				result.Message = proc.Text + result.Message
-			case config.ProcessorPositionAppend:
+			case config.ProcessorMutateAppend:
 				result.Message += proc.Text
 			}
 			logger.Info("text-mode processor applied",
 				"name", proc.Name,
-				"position", proc.GetPosition(),
+				"mutate", proc.GetMutate(),
 			)
 			continue
 		}
@@ -224,6 +226,15 @@ type Manager struct {
 	totalActivations int       // Total number of pipeline invocations (Apply calls) across session lifetime
 	lastActivationAt time.Time // When the pipeline was last invoked (zero if never)
 	lastAppliedNames []string  // Names of processors applied on the most recent activation
+
+	// stateStore persists agentResponseCount and per-processor cadence state across
+	// session restarts. Defaults to FileStateStore (writes processor_state.json in
+	// the session directory). Injected as MemoryStateStore in unit tests.
+	stateStore StateStore
+
+	// clock returns the current time. Defaults to time.Now; overridden in tests
+	// to make time-based cadence deterministic.
+	clock func() time.Time
 }
 
 // processorRunState tracks when a processor last ran, for rerun scheduling.
@@ -242,7 +253,21 @@ func NewManager(processorsDir string, logger *slog.Logger) *Manager {
 		processorsDir: processorsDir,
 		logger:        logger,
 		rerunState:    make(map[string]*processorRunState),
+		stateStore:    &FileStateStore{},
+		clock:         time.Now,
 	}
+}
+
+// SetStateStore replaces the state store used for persistence.
+// Primarily used in unit tests to inject a MemoryStateStore.
+func (m *Manager) SetStateStore(s StateStore) {
+	m.stateStore = s
+}
+
+// SetClock replaces the clock function used for cadence time checks.
+// Primarily used in unit tests to make time-based cadence deterministic.
+func (m *Manager) SetClock(fn func() time.Time) {
+	m.clock = fn
 }
 
 // AddTextProcessors converts config.MessageProcessor entries into unified Processor
@@ -260,8 +285,8 @@ func (m *Manager) AddTextProcessors(procs []config.MessageProcessor, priority in
 	for i, p := range procs {
 		proc := &Processor{
 			Name:     fmt.Sprintf("text-processor-%d", i),
-			When:     p.When,
-			Position: p.Position,
+			When:     WhenConfig{On: PhaseUserPrompt, Match: Match(p.When.Match)},
+			Mutate:   p.Mutate,
 			Text:     p.Text,
 			Priority: priority,
 			Source:   ProcessorSourceConfig,
@@ -307,6 +332,8 @@ func (m *Manager) CloneWithTextProcessors(procs []config.MessageProcessor, prior
 		promptFunc:       m.promptFunc,
 		totalActivations: activations,
 		lastActivationAt: lastAt,
+		stateStore:       m.stateStore,
+		clock:            m.clock,
 	}
 	copy(clone.processors, m.processors)
 	clone.AddTextProcessors(procs, priority)
@@ -338,6 +365,8 @@ func (m *Manager) CloneWithDirProcessors(dirs []string, logger *slog.Logger) *Ma
 		promptFunc:       m.promptFunc,
 		totalActivations: activations,
 		lastActivationAt: lastAt,
+		stateStore:       m.stateStore,
+		clock:            m.clock,
 	}
 	copy(clone.processors, m.processors)
 
@@ -424,6 +453,8 @@ func (m *Manager) CloneWithEnabledOverrides(overrides []config.ProcessorOverride
 		promptFunc:       m.promptFunc,
 		totalActivations: activations,
 		lastActivationAt: lastAt,
+		stateStore:       m.stateStore,
+		clock:            m.clock,
 	}
 
 	// Deep-copy processor pointers so we can modify Enabled without affecting the original.
@@ -464,11 +495,11 @@ func (m *Manager) Processors() []*Processor {
 }
 
 // Apply applies all applicable processors to a message.
-// Handles rerun logic for "when: first" processors: if a processor has a rerun config,
+// Handles rerun logic for "when.sent: first" processors: if a processor has a when.rerun config,
 // it tracks when the processor last ran and re-fires it when a threshold is reached.
 // Returns the processor result containing the transformed message and any attachments.
 func (m *Manager) Apply(ctx context.Context, input *ProcessorInput) (*ProcessorResult, error) {
-	// Pre-pass: check rerun eligibility for when:first processors.
+	// Pre-pass: check rerun eligibility for when.sent:first processors.
 	// We temporarily override isFirstMessage for processors that are due for re-run.
 	rerunOverrides := m.checkRerunEligibility(input)
 
@@ -511,18 +542,18 @@ func (m *Manager) hasPromptModeProcessors() bool {
 	return false
 }
 
-// checkRerunEligibility checks which "when: first" processors with rerun config
+// checkRerunEligibility checks which "when.on: userPrompt, match: first" processors with when.rerun config
 // are due for re-run. Returns a map of processor names to the reason they should be re-triggered.
 func (m *Manager) checkRerunEligibility(input *ProcessorInput) map[string]RerunReason {
 	if input.IsFirstMessage {
-		return nil // First message — all "when: first" processors will fire naturally
+		return nil // First message — all "match: first" processors will fire naturally
 	}
 
 	overrides := make(map[string]RerunReason)
 	now := time.Now()
 
 	for _, proc := range m.processors {
-		if proc.When != config.ProcessorWhenFirst || proc.Rerun == nil || proc.Name == "" {
+		if proc.When.On != PhaseUserPrompt || proc.When.Match != MatchFirst || proc.When.Rerun == nil || proc.Name == "" {
 			continue
 		}
 
@@ -531,7 +562,7 @@ func (m *Manager) checkRerunEligibility(input *ProcessorInput) map[string]RerunR
 			continue // Never ran yet — will be handled by isFirstMessage
 		}
 
-		rerun := proc.Rerun
+		rerun := proc.When.Rerun
 		// Check time threshold
 		if rerun.GetAfterDuration() > 0 && now.Sub(state.lastRunTime) >= rerun.GetAfterDuration() {
 			m.logger.Info("processor rerun triggered by time",
@@ -601,7 +632,8 @@ func (m *Manager) applyWithRerun(ctx context.Context, input *ProcessorInput, ori
 			m.logger.Debug("processor skipped",
 				"name", proc.Name,
 				"reason", string(skipReason),
-				"when", proc.When,
+				"on", proc.When.On,
+				"match", proc.When.Match,
 				"priority", proc.GetPriority(),
 			)
 			continue
@@ -612,9 +644,10 @@ func (m *Manager) applyWithRerun(ctx context.Context, input *ProcessorInput, ori
 		rerunReason, isRerun := rerunOverrides[proc.Name]
 		m.logger.Info("applying processor",
 			"name", proc.Name,
-			"when", proc.When,
+			"on", proc.When.On,
+			"match", proc.When.Match,
 			"mode", map[bool]string{true: "text", false: "command"}[proc.IsTextMode()],
-			"position", proc.GetPosition(),
+			"mutate", proc.GetMutate(),
 			"priority", proc.GetPriority(),
 			"is_rerun", isRerun,
 			"rerun_reason", string(rerunReason),
@@ -623,10 +656,10 @@ func (m *Manager) applyWithRerun(ctx context.Context, input *ProcessorInput, ori
 		// Text-mode: directly prepend or append the static text (no external command).
 		if proc.IsTextMode() {
 			text := SubstituteVariables(proc.Text, input)
-			switch proc.GetPosition() {
-			case config.ProcessorPositionPrepend:
+			switch proc.GetMutate() {
+			case config.ProcessorMutatePrepend:
 				result.Message = text + result.Message
-			case config.ProcessorPositionAppend:
+			case config.ProcessorMutateAppend:
 				result.Message += text
 			}
 			input.Message = result.Message
@@ -697,7 +730,7 @@ func (m *Manager) applyWithRerun(ctx context.Context, input *ProcessorInput, ori
 		}
 
 		// Record run for rerun tracking
-		if proc.Name != "" && proc.Rerun != nil {
+		if proc.Name != "" && proc.When.Rerun != nil {
 			m.rerunState[proc.Name] = &processorRunState{
 				lastRunTime:   time.Now(),
 				messagesSince: 0,
@@ -736,7 +769,7 @@ func (m *Manager) applyWithRerun(ctx context.Context, input *ProcessorInput, ori
 // increment the message counter.
 func (m *Manager) updateRerunState(wasFirstMessage bool) {
 	for _, proc := range m.processors {
-		if proc.When != config.ProcessorWhenFirst || proc.Rerun == nil || proc.Name == "" {
+		if proc.When.On != PhaseUserPrompt || proc.When.Match != MatchFirst || proc.When.Rerun == nil || proc.Name == "" {
 			continue
 		}
 
@@ -765,7 +798,7 @@ func (m *Manager) AccumulateTokenUsage(totalTokens int) {
 		return
 	}
 	for _, proc := range m.processors {
-		if proc.When != config.ProcessorWhenFirst || proc.Rerun == nil || proc.Name == "" {
+		if proc.When.On != PhaseUserPrompt || proc.When.Match != MatchFirst || proc.When.Rerun == nil || proc.Name == "" {
 			continue
 		}
 		state, exists := m.rerunState[proc.Name]
@@ -774,6 +807,305 @@ func (m *Manager) AccumulateTokenUsage(totalTokens int) {
 		}
 		state.tokensSince += totalTokens
 	}
+}
+
+// ApplyAfter runs all agentResponded processors against the completed agent turn.
+// It applies stop-reason, origin, match, and cadence filters in declaration order,
+// executes each processor (command or prompt mode), and accumulates side-effects.
+//
+// Persistence: the session's AgentResponseCount and per-processor cadence state are
+// loaded from input.SessionDir at the start and saved atomically after all processors
+// have run. If input.SessionDir is empty (tests, store-less sessions), state is held
+// only in the injected StateStore (MemoryStateStore in tests).
+//
+// Returns an ApplyAfterResult — never returns an error; individual processor failures
+// are collected non-fatally in ApplyAfterResult.Errors.
+func (m *Manager) ApplyAfter(ctx context.Context, input AfterProcessorInput) ApplyAfterResult {
+	// --- Load persisted state ---
+	store := m.stateStore
+	if store == nil {
+		store = &FileStateStore{}
+	}
+	state, err := store.Load(input.SessionDir)
+	if err != nil {
+		m.logger.Warn("after-phase: failed to load processor state, using zero-value",
+			"error", err, "session_dir", input.SessionDir)
+		state = &ProcessorStateData{Processors: make(map[string]*ProcessorCadenceState)}
+	}
+
+	isFirstAgentResponse := state.AgentResponseCount == 0
+	now := m.clock()
+
+	// Determine cumulative token count for this turn.
+	var turnTokens int64
+	if input.TokenUsage != nil {
+		turnTokens = input.TokenUsage.Total
+	}
+
+	var result ApplyAfterResult
+	applied := 0
+	skipped := 0
+
+	m.logger.Info("after-phase processor pipeline starting",
+		"total_processors", len(m.processors),
+		"is_first_agent_response", isFirstAgentResponse,
+		"agent_response_count", state.AgentResponseCount,
+		"stop_reason", input.StopReason,
+		"origin", input.Origin,
+	)
+
+	for _, proc := range m.processors {
+		// Phase filter: only agentResponded processors fire here.
+		if proc.When.On != PhaseAgentResponded {
+			continue
+		}
+
+		// Enabled check
+		if !proc.IsEnabled() {
+			skipped++
+			m.logger.Debug("after-phase processor skipped",
+				"name", proc.Name, "reason", "disabled")
+			continue
+		}
+
+		// StopReason filter
+		if len(proc.When.StopReasons) > 0 {
+			matched := false
+			for _, sr := range proc.When.StopReasons {
+				if sr == input.StopReason {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				skipped++
+				m.logger.Debug("after-phase processor skipped",
+					"name", proc.Name, "reason", "stopReason_mismatch",
+					"stop_reason", input.StopReason, "allowed", proc.When.StopReasons)
+				continue
+			}
+		}
+
+		// Origin filter (excludeOrigins)
+		if len(proc.When.ExcludeOrigins) > 0 {
+			excluded := false
+			for _, o := range proc.When.ExcludeOrigins {
+				if o == input.Origin {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				skipped++
+				m.logger.Debug("after-phase processor skipped",
+					"name", proc.Name, "reason", "origin_excluded",
+					"origin", input.Origin)
+				continue
+			}
+		}
+
+		// Match filter (uses persisted AgentResponseCount for correctness across restarts)
+		switch proc.When.Match {
+		case MatchFirst:
+			if !isFirstAgentResponse {
+				skipped++
+				m.logger.Debug("after-phase processor skipped",
+					"name", proc.Name, "reason", "match=first_not_first_response")
+				continue
+			}
+		case MatchAll:
+			// always passes match filter (cadence may still gate it)
+		case MatchAllExceptFirst:
+			if isFirstAgentResponse {
+				skipped++
+				m.logger.Debug("after-phase processor skipped",
+					"name", proc.Name, "reason", "match=allExceptFirst_is_first_response")
+				continue
+			}
+		default:
+			skipped++
+			m.logger.Warn("after-phase processor skipped: unknown match value",
+				"name", proc.Name, "match", proc.When.Match)
+			continue
+		}
+
+		// Cadence filter — gates processors with when.cadence configured.
+		// All specified thresholds must be met simultaneously (AND logic).
+		// Pre-increment semantics: TurnsSinceLastFire is incremented BEFORE the gate
+		// check so that everyNTurns:N means "fire every N agent responses that pass
+		// all other filters (stop reason, origin, match)".
+		if proc.When.Cadence != nil && proc.Name != "" {
+			cadenceState := state.Processors[proc.Name]
+			if cadenceState == nil {
+				cadenceState = &ProcessorCadenceState{}
+				state.Processors[proc.Name] = cadenceState
+			}
+			c := proc.When.Cadence
+
+			// Pre-increment counters for this turn.
+			cadenceState.TurnsSinceLastFire++
+			cadenceState.TokensSinceLastFire += turnTokens
+
+			// Check all thresholds (AND logic).
+			gatePassed := true
+
+			if c.EveryNTurns > 0 && cadenceState.TurnsSinceLastFire < c.EveryNTurns {
+				gatePassed = false
+				m.logger.Debug("after-phase processor cadence: turns threshold not met",
+					"name", proc.Name,
+					"turns_since_last_fire", cadenceState.TurnsSinceLastFire,
+					"required", c.EveryNTurns)
+			}
+			if gatePassed && c.EveryNTokens > 0 && cadenceState.TokensSinceLastFire < c.EveryNTokens {
+				gatePassed = false
+				m.logger.Debug("after-phase processor cadence: tokens threshold not met",
+					"name", proc.Name,
+					"tokens_since_last_fire", cadenceState.TokensSinceLastFire,
+					"required", c.EveryNTokens)
+			}
+			if gatePassed && c.AfterInterval != "" {
+				interval := c.GetAfterIntervalDuration()
+				if interval > 0 && !cadenceState.LastFiredAt.IsZero() {
+					elapsed := now.Sub(cadenceState.LastFiredAt)
+					if elapsed < interval {
+						gatePassed = false
+						m.logger.Debug("after-phase processor cadence: interval threshold not met",
+							"name", proc.Name,
+							"elapsed", elapsed,
+							"required", interval)
+					}
+				}
+			}
+
+			if !gatePassed {
+				skipped++
+				continue
+			}
+		}
+
+		applied++
+		m.logger.Info("applying after-phase processor",
+			"name", proc.Name,
+			"match", proc.When.Match,
+			"output", proc.GetOutput(),
+		)
+
+		// Execute the processor and collect stdout.
+		var stdout string
+		var execErr error
+
+		if proc.IsPromptMode() {
+			stdout, execErr = executeAfterPrompt(proc, input)
+		} else {
+			// Command mode (text mode is forbidden for agentResponded by the loader).
+			stdout, execErr = executeAfterCommand(ctx, proc, m.processorsDir, input, m.logger)
+		}
+
+		if execErr != nil {
+			m.logger.Warn("after-phase processor execution failed",
+				"name", proc.Name, "error", execErr)
+			result.Errors = append(result.Errors, ProcessorError{
+				ProcessorName: proc.Name,
+				Error:         execErr.Error(),
+			})
+			continue
+		}
+
+		// After a successful execution, reset cadence counters for this processor.
+		if proc.When.Cadence != nil && proc.Name != "" {
+			cs := state.Processors[proc.Name]
+			if cs == nil {
+				cs = &ProcessorCadenceState{}
+				state.Processors[proc.Name] = cs
+			}
+			cs.TurnsSinceLastFire = 0
+			cs.TokensSinceLastFire = 0
+			cs.LastFiredAt = now
+		}
+
+		// Parse output according to output type.
+		outputType := proc.GetOutput()
+		if outputType == OutputTransform || outputType == OutputPrepend || outputType == OutputAppend {
+			// These are forbidden for agentResponded by the loader; treat as discard.
+			outputType = OutputDiscard
+		}
+
+		switch outputType {
+		case OutputDiscard:
+			// Side-effects only; stdout is intentionally discarded.
+
+		case OutputNotify:
+			notifs, parseErr := parseNotifyOutput(stdout)
+			if parseErr != nil {
+				m.logger.Warn("after-phase processor notify parse failed",
+					"name", proc.Name, "error", parseErr)
+				result.Errors = append(result.Errors, ProcessorError{
+					ProcessorName: proc.Name,
+					Error:         parseErr.Error(),
+				})
+				continue
+			}
+			result.Notifications = append(result.Notifications, notifs...)
+
+		case OutputActionButtons:
+			buttons, parseErr := parseActionButtonsOutput(stdout)
+			if parseErr != nil {
+				m.logger.Warn("after-phase processor actionButtons parse failed",
+					"name", proc.Name, "error", parseErr)
+				result.Errors = append(result.Errors, ProcessorError{
+					ProcessorName: proc.Name,
+					Error:         parseErr.Error(),
+				})
+				continue
+			}
+			result.ActionButtons = append(result.ActionButtons, buttons...)
+
+		case OutputUserData:
+			patch, parseErr := parseUserDataOutput(stdout)
+			if parseErr != nil {
+				m.logger.Warn("after-phase processor userData parse failed",
+					"name", proc.Name, "error", parseErr)
+				result.Errors = append(result.Errors, ProcessorError{
+					ProcessorName: proc.Name,
+					Error:         parseErr.Error(),
+				})
+				continue
+			}
+			if len(patch) > 0 {
+				if result.UserDataPatch == nil {
+					result.UserDataPatch = make(map[string]string)
+				}
+				for k, v := range patch {
+					result.UserDataPatch[k] = v
+				}
+			}
+		}
+
+		m.logger.Info("after-phase processor applied",
+			"name", proc.Name, "output_type", outputType)
+	}
+
+	// --- Update and save persisted state ---
+	// Increment global response count so next call knows it's not the first response.
+	state.AgentResponseCount++
+
+	if saveErr := store.Save(input.SessionDir, state); saveErr != nil {
+		m.logger.Warn("after-phase: failed to save processor state",
+			"error", saveErr, "session_dir", input.SessionDir)
+	}
+
+	m.logger.Info("after-phase processor pipeline complete",
+		"total", len(m.processors),
+		"applied", applied,
+		"skipped", skipped,
+		"agent_response_count", state.AgentResponseCount,
+		"notifications", len(result.Notifications),
+		"action_buttons", len(result.ActionButtons),
+		"user_data_keys", len(result.UserDataPatch),
+		"errors", len(result.Errors),
+	)
+
+	return result
 }
 
 // EstimateTokens estimates the number of tokens in a text string.

--- a/internal/processors/hook.go
+++ b/internal/processors/hook.go
@@ -76,32 +76,42 @@ func (h *Processor) GetOnError() ErrorHandling {
 	return h.OnError
 }
 
-// GetPosition returns the processor's position, using prepend as default.
-func (h *Processor) GetPosition() config.ProcessorPosition {
-	if h.Position == "" {
-		return config.ProcessorPositionPrepend
+// GetMutate returns the processor's mutate setting, using prepend as default.
+func (h *Processor) GetMutate() config.ProcessorMutate {
+	if h.Mutate == "" {
+		return config.ProcessorMutatePrepend
 	}
-	return h.Position
+	return h.Mutate
 }
 
 // SkipReason describes why a processor was not applied.
 type SkipReason string
 
 const (
-	SkipReasonNone            SkipReason = ""
-	SkipReasonDisabled        SkipReason = "disabled"
-	SkipReasonEnabledWhen     SkipReason = "enabledWhen_false"
-	SkipReasonWhenFirst       SkipReason = "when=first_not_first_message"
-	SkipReasonWhenExceptFirst SkipReason = "when=all-except-first_is_first_message"
-	SkipReasonWhenUnknown     SkipReason = "unknown_when_condition"
-	SkipReasonRerunNotDue     SkipReason = "rerun_not_due"
+	SkipReasonNone             SkipReason = ""
+	SkipReasonDisabled         SkipReason = "disabled"
+	SkipReasonEnabledWhen      SkipReason = "enabledWhen_false"
+	SkipReasonMatchFirst       SkipReason = "match=first_not_first_message"
+	SkipReasonMatchAllExcFirst SkipReason = "match=allExceptFirst_is_first_message"
+	SkipReasonMatchUnknown     SkipReason = "unknown_match_condition"
+	SkipReasonRerunNotDue      SkipReason = "rerun_not_due"
+	// SkipReasonAgentRespondedPhase is applied to agentResponded processors in the
+	// userPrompt pipeline. These processors are only executed via Manager.ApplyAfter.
+	SkipReasonAgentRespondedPhase SkipReason = "agentResponded_phase"
 )
 
 // ShouldApply returns true if the processor should apply given the message context.
 // When it returns false, the SkipReason describes why.
+// Note: PhaseAgentResponded processors are always skipped here — they run in a separate path (Task 3).
 func (h *Processor) ShouldApply(isFirstMessage bool, input *ProcessorInput) (bool, SkipReason) {
 	if !h.IsEnabled() {
 		return false, SkipReasonDisabled
+	}
+
+	// agentResponded processors are always skipped in the userPrompt pipeline.
+	// They are executed exclusively via Manager.ApplyAfter after the agent responds.
+	if h.When.On == PhaseAgentResponded {
+		return false, SkipReasonAgentRespondedPhase
 	}
 
 	// Check CEL expression (enabledWhen)
@@ -130,22 +140,22 @@ func (h *Processor) ShouldApply(isFirstMessage bool, input *ProcessorInput) (boo
 		}
 	}
 
-	// Check when condition
-	switch h.When {
-	case config.ProcessorWhenFirst:
+	// Check match condition
+	switch h.When.Match {
+	case MatchFirst:
 		if !isFirstMessage {
-			return false, SkipReasonWhenFirst
+			return false, SkipReasonMatchFirst
 		}
 		return true, SkipReasonNone
-	case config.ProcessorWhenAll:
+	case MatchAll:
 		return true, SkipReasonNone
-	case config.ProcessorWhenAllExceptFirst:
+	case MatchAllExceptFirst:
 		if isFirstMessage {
-			return false, SkipReasonWhenExceptFirst
+			return false, SkipReasonMatchAllExcFirst
 		}
 		return true, SkipReasonNone
 	default:
-		return false, SkipReasonWhenUnknown
+		return false, SkipReasonMatchUnknown
 	}
 }
 

--- a/internal/processors/loader.go
+++ b/internal/processors/loader.go
@@ -119,6 +119,12 @@ func (l *Loader) Load() ([]*Processor, error) {
 	return procs, nil
 }
 
+// LoadFile loads and validates a single processor from a YAML file.
+// Exported for use in tests that need to validate individual processor definitions.
+func (l *Loader) LoadFile(path string) (*Processor, error) {
+	return l.loadProcessorFile(path)
+}
+
 // loadProcessorFile loads a single processor from a YAML file.
 func (l *Loader) loadProcessorFile(path string) (*Processor, error) {
 	data, err := os.ReadFile(path)
@@ -143,17 +149,97 @@ func (l *Loader) loadProcessorFile(path string) (*Processor, error) {
 	if proc.Prompt != "" && (proc.Command != "" || proc.Text != "") {
 		return nil, fmt.Errorf("processor with 'prompt' must not specify 'command' or 'text'")
 	}
-	if proc.When == "" {
-		return nil, fmt.Errorf("processor 'when' is required")
+
+	// Validate when.on
+	if proc.When.On == "" {
+		return nil, fmt.Errorf("processor 'when.on' is required (must be 'userPrompt' or 'agentResponded')")
+	}
+	if proc.When.On != PhaseUserPrompt && proc.When.On != PhaseAgentResponded {
+		return nil, fmt.Errorf("processor 'when.on' has invalid value %q; must be 'userPrompt' or 'agentResponded'", proc.When.On)
 	}
 
-	// Validate rerun config
-	if proc.Rerun != nil {
-		if proc.When != "first" {
-			return nil, fmt.Errorf("'rerun' is only supported with 'when: first', got 'when: %s'", proc.When)
+	// Validate when.match
+	if proc.When.Match == "" {
+		return nil, fmt.Errorf("processor 'when.match' is required (must be 'first', 'all', or 'allExceptFirst')")
+	}
+	switch proc.When.Match {
+	case MatchFirst, MatchAll, MatchAllExceptFirst:
+		// valid
+	case "all-except-first":
+		return nil, fmt.Errorf("processor 'when.match' value %q is no longer accepted; use 'allExceptFirst' (camelCase) — kebab-case is no longer accepted", proc.When.Match)
+	default:
+		return nil, fmt.Errorf("processor 'when.match' has invalid value %q; must be 'first', 'all', or 'allExceptFirst'", proc.When.Match)
+	}
+
+	// Phase-specific validation
+	switch proc.When.On {
+	case PhaseAgentResponded:
+		// Text mode forbidden for agentResponded
+		if proc.Text != "" {
+			return nil, fmt.Errorf("processor 'text' is not allowed for 'when.on: agentResponded' (use command or prompt mode)")
 		}
-		if err := proc.Rerun.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid rerun config: %w", err)
+		// mutate forbidden for agentResponded
+		if proc.Mutate != "" {
+			return nil, fmt.Errorf("processor 'mutate' is not allowed for 'when.on: agentResponded'")
+		}
+		// rerun forbidden for agentResponded
+		if proc.When.Rerun != nil {
+			return nil, fmt.Errorf("processor 'when.rerun' is not allowed for 'when.on: agentResponded'")
+		}
+		// output transform/prepend/append forbidden for agentResponded
+		if proc.Output == OutputTransform || proc.Output == OutputPrepend || proc.Output == OutputAppend {
+			return nil, fmt.Errorf("processor 'output: %s' is not allowed for 'when.on: agentResponded'; use 'discard', 'notify', 'actionButtons', or 'userData'", proc.Output)
+		}
+		// Default stopReasons to ["end_turn"] if not specified.
+		// These match the ACP SDK StopReason constants (snake_case).
+		if len(proc.When.StopReasons) == 0 {
+			proc.When.StopReasons = []string{"end_turn"}
+		}
+		// cadence validation (rules 12-15)
+		if proc.When.Cadence != nil {
+			c := proc.When.Cadence
+			// Rule 12: cadence + match:first is disallowed (first-response semantics are implicit)
+			if proc.When.Match == MatchFirst {
+				return nil, fmt.Errorf("processor 'when.cadence' is not allowed with 'when.match: first' (first-response semantics are already built-in)")
+			}
+			// Rule 13: at least one threshold must be specified
+			if c.EveryNTurns == 0 && c.EveryNTokens == 0 && c.AfterInterval == "" {
+				return nil, fmt.Errorf("processor 'when.cadence' must specify at least one of: everyNTurns, everyNTokens, afterInterval")
+			}
+			// Rule 14: EveryNTurns must be ≥ 1 when specified
+			if c.EveryNTurns < 0 {
+				return nil, fmt.Errorf("processor 'when.cadence.everyNTurns' must be ≥ 1, got %d", c.EveryNTurns)
+			}
+			// Rule 15: EveryNTokens must be ≥ 1 when specified
+			if c.EveryNTokens < 0 {
+				return nil, fmt.Errorf("processor 'when.cadence.everyNTokens' must be ≥ 1, got %d", c.EveryNTokens)
+			}
+			// Rule 16: AfterInterval must be a valid Go duration string
+			if c.AfterInterval != "" && c.GetAfterIntervalDuration() == 0 {
+				return nil, fmt.Errorf("processor 'when.cadence.afterInterval' has invalid duration %q (use Go duration syntax, e.g. '5m', '1h')", c.AfterInterval)
+			}
+		}
+
+	case PhaseUserPrompt:
+		// stopReasons and excludeOrigins are only for agentResponded
+		if len(proc.When.StopReasons) > 0 {
+			return nil, fmt.Errorf("processor 'when.stopReasons' is only valid for 'when.on: agentResponded'")
+		}
+		if len(proc.When.ExcludeOrigins) > 0 {
+			return nil, fmt.Errorf("processor 'when.excludeOrigins' is only valid for 'when.on: agentResponded'")
+		}
+		// rerun only valid with match:first
+		if proc.When.Rerun != nil {
+			if proc.When.Match != MatchFirst {
+				return nil, fmt.Errorf("'when.rerun' is only supported with 'when.match: first', got 'when.match: %s'", proc.When.Match)
+			}
+			if err := proc.When.Rerun.Validate(); err != nil {
+				return nil, fmt.Errorf("invalid rerun config: %w", err)
+			}
+		}
+		// Text mode requires mutate
+		if proc.IsTextMode() && proc.Mutate == "" {
+			return nil, fmt.Errorf("text-mode processor requires 'mutate: prepend' or 'mutate: append'")
 		}
 	}
 

--- a/internal/processors/processors_test.go
+++ b/internal/processors/processors_test.go
@@ -82,49 +82,49 @@ func TestProcessorShouldApply(t *testing.T) {
 	}{
 		{
 			name:           "disabled hook",
-			hook:           &Processor{Enabled: boolPtr(false), When: config.ProcessorWhenAll},
+			hook:           &Processor{Enabled: boolPtr(false), When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}},
 			isFirstMessage: true,
 			expected:       false,
 		},
 		{
 			name:           "when=first, is first",
-			hook:           &Processor{When: config.ProcessorWhenFirst},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchFirst}},
 			isFirstMessage: true,
 			expected:       true,
 		},
 		{
 			name:           "when=first, not first",
-			hook:           &Processor{When: config.ProcessorWhenFirst},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchFirst}},
 			isFirstMessage: false,
 			expected:       false,
 		},
 		{
 			name:           "when=all, is first",
-			hook:           &Processor{When: config.ProcessorWhenAll},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}},
 			isFirstMessage: true,
 			expected:       true,
 		},
 		{
 			name:           "when=all, not first",
-			hook:           &Processor{When: config.ProcessorWhenAll},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}},
 			isFirstMessage: false,
 			expected:       true,
 		},
 		{
 			name:           "when=all-except-first, is first",
-			hook:           &Processor{When: config.ProcessorWhenAllExceptFirst},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAllExceptFirst}},
 			isFirstMessage: true,
 			expected:       false,
 		},
 		{
 			name:           "when=all-except-first, not first",
-			hook:           &Processor{When: config.ProcessorWhenAllExceptFirst},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAllExceptFirst}},
 			isFirstMessage: false,
 			expected:       true,
 		},
 		{
 			name: "enabledWhen CEL matches acp.name",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `acp.name == "auggie-opus"`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `acp.name == "auggie-opus"`},
 			input: &ProcessorInput{
 				ACPServer: "auggie-opus",
 				AvailableACPServers: []AvailableACPServer{
@@ -136,7 +136,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL acp.name no match",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `acp.name == "auggie-opus"`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `acp.name == "auggie-opus"`},
 			input: &ProcessorInput{
 				ACPServer: "auggie-fast",
 				AvailableACPServers: []AvailableACPServer{
@@ -148,7 +148,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL matches acp.tags",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `acp.tags.exists(t, t == "reasoning")`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `acp.tags.exists(t, t == "reasoning")`},
 			input: &ProcessorInput{
 				ACPServer: "auggie-opus",
 				AvailableACPServers: []AvailableACPServer{
@@ -160,7 +160,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL tags no match",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `acp.tags.exists(t, t == "reasoning")`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `acp.tags.exists(t, t == "reasoning")`},
 			input: &ProcessorInput{
 				ACPServer: "auggie-fast",
 				AvailableACPServers: []AvailableACPServer{
@@ -172,7 +172,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL children.exists",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `children.exists`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `children.exists`},
 			input: &ProcessorInput{
 				ChildSessions: []ChildSession{
 					{ID: "child-1", Name: "Sub task"},
@@ -183,14 +183,14 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name:           "enabledWhen CEL children.exists false",
-			hook:           &Processor{When: config.ProcessorWhenAll, EnabledWhen: `children.exists`},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `children.exists`},
 			input:          &ProcessorInput{},
 			isFirstMessage: true,
 			expected:       false,
 		},
 		{
 			name: "enabledWhen CEL children.mcp_count threshold met",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `children.mcp_count >= 2`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `children.mcp_count >= 2`},
 			input: &ProcessorInput{
 				ChildSessions: []ChildSession{
 					{ID: "child-1", Name: "Task A", ChildOrigin: "mcp"},
@@ -202,7 +202,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL children.mcp_count below threshold",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `children.mcp_count >= 2`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `children.mcp_count >= 2`},
 			input: &ProcessorInput{
 				ChildSessions: []ChildSession{
 					{ID: "child-1", Name: "Task A", ChildOrigin: "mcp"},
@@ -214,7 +214,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL invalid expression fails open",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `!!!invalid`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `!!!invalid`},
 			input: &ProcessorInput{
 				ACPServer: "test",
 			},
@@ -223,14 +223,14 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name:           "enabledWhen empty means all",
-			hook:           &Processor{When: config.ProcessorWhenAll, EnabledWhen: ""},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: ""},
 			input:          &ProcessorInput{ACPServer: "anything"},
 			isFirstMessage: true,
 			expected:       true,
 		},
 		{
 			name: "tools.hasAllPatterns all patterns satisfied",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasAllPatterns(["mitto_*", "jira_*"])`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasAllPatterns(["mitto_*", "jira_*"])`},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"mitto_conversation_new", "mitto_conversation_list", "jira_search"},
 			},
@@ -239,7 +239,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "tools.hasAllPatterns some patterns not satisfied",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasAllPatterns(["mitto_*", "slack_*"])`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasAllPatterns(["mitto_*", "slack_*"])`},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"mitto_conversation_new", "jira_search"},
 			},
@@ -248,14 +248,14 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name:           "tools.hasPattern no tools available",
-			hook:           &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasPattern("mitto_*")`},
+			hook:           &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasPattern("mitto_*")`},
 			input:          &ProcessorInput{MCPToolNames: []string{}},
 			isFirstMessage: true,
 			expected:       false,
 		},
 		{
 			name: "enabledWhen empty tools means all",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: ""},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: ""},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"anything"},
 			},
@@ -264,7 +264,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "tools.hasPattern exact tool match",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasPattern("mitto_conversation_new")`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasPattern("mitto_conversation_new")`},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"mitto_conversation_new", "mitto_conversation_list"},
 			},
@@ -273,7 +273,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL tools.hasPattern",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasPattern("mitto_*")`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasPattern("mitto_*")`},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"mitto_conversation_new", "mitto_conversation_list"},
 			},
@@ -282,7 +282,7 @@ func TestProcessorShouldApply(t *testing.T) {
 		},
 		{
 			name: "enabledWhen CEL tools.hasPattern no match",
-			hook: &Processor{When: config.ProcessorWhenAll, EnabledWhen: `tools.hasPattern("slack_*")`},
+			hook: &Processor{When: WhenConfig{On: PhaseUserPrompt, Match: MatchAll}, EnabledWhen: `tools.hasPattern("slack_*")`},
 			input: &ProcessorInput{
 				MCPToolNames: []string{"mitto_conversation_new", "jira_search"},
 			},
@@ -306,11 +306,13 @@ func TestManagerApply_RerunAfterTime(t *testing.T) {
 	writeYAML(t, dir, "ctx.yaml", `
 name: context-injector
 enabled: true
-when: first
-position: prepend
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTime: 50ms
+mutate: prepend
 text: "[context]"
-rerun:
-  afterTime: 50ms
 `)
 
 	mgr := NewManager(dir, nil)
@@ -359,11 +361,13 @@ func TestManagerApply_RerunAfterMsgs(t *testing.T) {
 	writeYAML(t, dir, "ctx.yaml", `
 name: context-injector
 enabled: true
-when: first
-position: prepend
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterSentMsgs: 3
+mutate: prepend
 text: "[context]"
-rerun:
-  afterSentMsgs: 3
 `)
 
 	mgr := NewManager(dir, nil)
@@ -424,11 +428,13 @@ func TestManagerApply_RerunAfterTokens(t *testing.T) {
 	writeYAML(t, dir, "ctx.yaml", `
 name: context-injector
 enabled: true
-when: first
+when:
+  on: userPrompt
+  match: first
+  rerun:
+    afterTokens: 1000
 text: "[CONTEXT]"
-position: prepend
-rerun:
-  afterTokens: 1000
+mutate: prepend
 `)
 
 	mgr := NewManager(dir, nil)
@@ -512,14 +518,13 @@ func TestAccumulateTokenUsage(t *testing.T) {
 	mgr := NewManager("", nil)
 	mgr.processors = []*Processor{
 		{
-			Name:  "tracked",
-			When:  config.ProcessorWhenFirst,
-			Text:  "test",
-			Rerun: &RerunConfig{AfterTokens: 100},
+			Name: "tracked",
+			When: WhenConfig{On: PhaseUserPrompt, Match: MatchFirst, Rerun: &RerunConfig{AfterTokens: 100}},
+			Text: "test",
 		},
 		{
 			Name: "no-rerun",
-			When: config.ProcessorWhenFirst,
+			When: WhenConfig{On: PhaseUserPrompt, Match: MatchFirst},
 			Text: "test2",
 		},
 	}
@@ -574,10 +579,13 @@ func TestLoader_RerunOnlyWithFirst(t *testing.T) {
 	writeYAML(t, dir, "bad.yaml", `
 name: bad-rerun
 enabled: true
-when: all
+when:
+  on: userPrompt
+  match: all
+  rerun:
+    afterTime: 10m
 text: "test"
-rerun:
-  afterTime: 10m
+mutate: prepend
 `)
 
 	loader := NewLoader(dir, nil)
@@ -588,6 +596,202 @@ rerun:
 	// The bad processor should have been skipped
 	if len(procs) != 0 {
 		t.Errorf("expected 0 processors (bad rerun config skipped), got %d", len(procs))
+	}
+}
+
+// TestLoader_Validation tests all validation rules for the new on/match schema.
+func TestLoader_Validation(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		expectSkip  bool // true = processor should be skipped (bad file), false = should load OK
+		expectCount int  // expected processor count after load
+	}{
+		{
+			name: "missing when.on rejected",
+			yaml: `
+name: bad-on
+when:
+  match: all
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "missing when.match rejected",
+			yaml: `
+name: bad-match
+when:
+  on: userPrompt
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "invalid when.on value rejected",
+			yaml: `
+name: bad-on-val
+when:
+  on: beforeSend
+  match: all
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "kebab-case all-except-first rejected",
+			yaml: `
+name: bad-kebab
+when:
+  on: userPrompt
+  match: all-except-first
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "camelCase allExceptFirst accepted",
+			yaml: `
+name: ok-camel
+when:
+  on: userPrompt
+  match: allExceptFirst
+command: /bin/echo
+`,
+			expectSkip:  false,
+			expectCount: 1,
+		},
+		{
+			name: "agentResponded with text rejected",
+			yaml: `
+name: bad-ar-text
+when:
+  on: agentResponded
+  match: all
+text: "some text"
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "agentResponded with mutate rejected",
+			yaml: `
+name: bad-ar-mutate
+when:
+  on: agentResponded
+  match: all
+mutate: prepend
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "agentResponded with rerun rejected",
+			yaml: `
+name: bad-ar-rerun
+when:
+  on: agentResponded
+  match: all
+  rerun:
+    afterTime: 10m
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "agentResponded command-mode accepted",
+			yaml: `
+name: ok-ar-cmd
+when:
+  on: agentResponded
+  match: all
+command: /bin/echo
+`,
+			expectSkip:  false,
+			expectCount: 1,
+		},
+		{
+			name: "agentResponded prompt-mode accepted",
+			yaml: `
+name: ok-ar-prompt
+when:
+  on: agentResponded
+  match: all
+prompt: "Analyze the session."
+`,
+			expectSkip:  false,
+			expectCount: 1,
+		},
+		{
+			name: "userPrompt stopReasons rejected",
+			yaml: `
+name: bad-up-stop
+when:
+  on: userPrompt
+  match: all
+  stopReasons: ["end_turn"]
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "userPrompt excludeOrigins rejected",
+			yaml: `
+name: bad-up-excl
+when:
+  on: userPrompt
+  match: all
+  excludeOrigins: ["user"]
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "legacy sent: key rejected",
+			yaml: `
+name: bad-sent
+when:
+  sent: all
+command: /bin/echo
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+		{
+			name: "text mode without mutate rejected",
+			yaml: `
+name: bad-text-no-mutate
+when:
+  on: userPrompt
+  match: all
+text: "hello"
+`,
+			expectSkip:  true,
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeYAML(t, dir, "proc.yaml", tt.yaml)
+			loader := NewLoader(dir, nil)
+			procs, err := loader.Load()
+			if err != nil {
+				t.Fatalf("Load() should not return error (bad files skipped), got: %v", err)
+			}
+			if len(procs) != tt.expectCount {
+				t.Errorf("expected %d processors, got %d", tt.expectCount, len(procs))
+			}
+		})
 	}
 }
 
@@ -621,7 +825,9 @@ func TestLoaderLoad(t *testing.T) {
 	hookContent := `
 name: test-hook
 command: /bin/echo
-when: all
+when:
+  on: userPrompt
+  match: all
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "test.yaml"), []byte(hookContent), 0644); err != nil {
 		t.Fatalf("Failed to write hook file: %v", err)
@@ -741,7 +947,7 @@ echo '{"message": "transformed message"}'
 		{
 			Name:    "transform-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputTransform,
 			Input:   InputMessage,
 			HookDir: tmpDir,
@@ -780,7 +986,7 @@ echo '{"text": "PREFIX: "}'
 		{
 			Name:    "prepend-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputPrepend,
 			Input:   InputNone,
 			HookDir: tmpDir,
@@ -819,7 +1025,7 @@ echo '{"text": " :SUFFIX"}'
 		{
 			Name:    "append-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputAppend,
 			Input:   InputNone,
 			HookDir: tmpDir,
@@ -859,7 +1065,7 @@ echo '{"message": "this should be ignored"}'
 		{
 			Name:    "discard-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputDiscard,
 			Input:   InputNone,
 			HookDir: tmpDir,
@@ -898,7 +1104,7 @@ echo '{"message": "first message only"}'
 		{
 			Name:    "first-only-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenFirst, // Only applies to first message
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchFirst}, // Only applies to first message
 			Output:  OutputTransform,
 			Input:   InputNone,
 			HookDir: tmpDir,
@@ -938,7 +1144,7 @@ exit 1
 		{
 			Name:    "failing-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputTransform,
 			OnError: ErrorSkip, // Should skip on error
 			HookDir: tmpDir,
@@ -977,7 +1183,7 @@ exit 1
 		{
 			Name:    "failing-hook",
 			Command: scriptPath,
-			When:    config.ProcessorWhenAll,
+			When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Output:  OutputTransform,
 			OnError: ErrorFail, // Should fail on error
 			HookDir: tmpDir,
@@ -1000,10 +1206,10 @@ exit 1
 func TestApplyProcessorsTextModePrepend(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "text-prepend",
-			Text:     "PREFIX: ",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenAll,
+			Name:   "text-prepend",
+			Text:   "PREFIX: ",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 	}
 
@@ -1025,10 +1231,10 @@ func TestApplyProcessorsTextModePrepend(t *testing.T) {
 func TestApplyProcessorsTextModeAppend(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "text-append",
-			Text:     " SUFFIX",
-			Position: config.ProcessorPositionAppend,
-			When:     config.ProcessorWhenAll,
+			Name:   "text-append",
+			Text:   " SUFFIX",
+			Mutate: config.ProcessorMutateAppend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 	}
 
@@ -1051,16 +1257,16 @@ func TestApplyProcessorsTextModeChained(t *testing.T) {
 	// Multiple text-mode processors applied in order
 	procs := []*Processor{
 		{
-			Name:     "prepend-context",
-			Text:     "Context: ",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenAll,
+			Name:   "prepend-context",
+			Text:   "Context: ",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 		{
-			Name:     "append-footer",
-			Text:     "\n---\nEnd",
-			Position: config.ProcessorPositionAppend,
-			When:     config.ProcessorWhenAll,
+			Name:   "append-footer",
+			Text:   "\n---\nEnd",
+			Mutate: config.ProcessorMutateAppend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 	}
 
@@ -1083,10 +1289,10 @@ func TestApplyProcessorsTextModeChained(t *testing.T) {
 func TestApplyProcessorsTextModeFirstOnly(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "first-only",
-			Text:     "FIRST: ",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenFirst,
+			Name:   "first-only",
+			Text:   "FIRST: ",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchFirst},
 		},
 	}
 
@@ -1119,16 +1325,16 @@ func TestApplyProcessorsTextModeFirstOnly(t *testing.T) {
 func TestApplyProcessorsWithVariableSubstitution(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "inject-context",
-			Text:     "Session: @mitto:session_id\nProject: @mitto:working_dir\n\n",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenFirst,
+			Name:   "inject-context",
+			Text:   "Session: @mitto:session_id\nProject: @mitto:working_dir\n\n",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchFirst},
 		},
 		{
-			Name:     "inject-footer",
-			Text:     "\n[agent: @mitto:acp_server]",
-			Position: config.ProcessorPositionAppend,
-			When:     config.ProcessorWhenAll,
+			Name:   "inject-footer",
+			Text:   "\n[agent: @mitto:acp_server]",
+			Mutate: config.ProcessorMutateAppend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 	}
 
@@ -1193,10 +1399,10 @@ func TestApplyProcessorsVariablesInUserMessage(t *testing.T) {
 func TestApplyProcessorsVariablesEmptyValues(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "context",
-			Text:     "Parent: @mitto:parent_session_id\n",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenAll,
+			Name:   "context",
+			Text:   "Parent: @mitto:parent_session_id\n",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 		},
 	}
 
@@ -1227,10 +1433,10 @@ func TestApplyProcessorsVariablesEmptyValues(t *testing.T) {
 func TestApplyProcessorsVariablesWithAvailableServers(t *testing.T) {
 	procs := []*Processor{
 		{
-			Name:     "server-info",
-			Text:     "Available: @mitto:available_acp_servers\n\n",
-			Position: config.ProcessorPositionPrepend,
-			When:     config.ProcessorWhenFirst,
+			Name:   "server-info",
+			Text:   "Available: @mitto:available_acp_servers\n\n",
+			Mutate: config.ProcessorMutatePrepend,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchFirst},
 		},
 	}
 
@@ -1265,7 +1471,9 @@ func TestManagerLoadAndApply(t *testing.T) {
 name: test-manager-hook
 command: /bin/echo
 args: ['{"message": "from manager"}']
-when: all
+when:
+  on: userPrompt
+  match: all
 output: transform
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "hook.yaml"), []byte(hookContent), 0644); err != nil {
@@ -1465,22 +1673,22 @@ func TestExecutorParseOutput(t *testing.T) {
 	}
 }
 
-func TestProcessorGetPosition(t *testing.T) {
+func TestProcessorGetMutate(t *testing.T) {
 	tests := []struct {
 		name     string
-		position config.ProcessorPosition
-		expected config.ProcessorPosition
+		mutate   config.ProcessorMutate
+		expected config.ProcessorMutate
 	}{
-		{"empty defaults to prepend", "", config.ProcessorPositionPrepend},
-		{"prepend", config.ProcessorPositionPrepend, config.ProcessorPositionPrepend},
-		{"append", config.ProcessorPositionAppend, config.ProcessorPositionAppend},
+		{"empty defaults to prepend", "", config.ProcessorMutatePrepend},
+		{"prepend", config.ProcessorMutatePrepend, config.ProcessorMutatePrepend},
+		{"append", config.ProcessorMutateAppend, config.ProcessorMutateAppend},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &Processor{Position: tt.position}
-			if got := h.GetPosition(); got != tt.expected {
-				t.Errorf("GetPosition() = %v, want %v", got, tt.expected)
+			h := &Processor{Mutate: tt.mutate}
+			if got := h.GetMutate(); got != tt.expected {
+				t.Errorf("GetMutate() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
@@ -1539,8 +1747,10 @@ func TestCloneWithDirProcessors(t *testing.T) {
 	writeYAML(t, globalDir, "global.yaml", `
 name: global-proc
 enabled: true
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 text: "global"
 `)
 
@@ -1549,8 +1759,10 @@ text: "global"
 	writeYAML(t, wsDir, "workspace.yaml", `
 name: ws-proc
 enabled: true
-when: all
-position: append
+when:
+  on: userPrompt
+  match: all
+mutate: append
 text: "workspace"
 `)
 
@@ -1587,8 +1799,10 @@ func TestCloneWithDirProcessors_Override(t *testing.T) {
 	writeYAML(t, globalDir, "shared.yaml", `
 name: shared
 enabled: true
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 text: "global version"
 `)
 
@@ -1597,8 +1811,10 @@ text: "global version"
 	writeYAML(t, wsDir, "shared.yaml", `
 name: shared
 enabled: true
-when: all
-position: append
+when:
+  on: userPrompt
+  match: all
+mutate: append
 text: "workspace version"
 `)
 
@@ -1616,8 +1832,8 @@ text: "workspace version"
 	if procs[0].Text != "workspace version" {
 		t.Errorf("expected workspace version, got %q", procs[0].Text)
 	}
-	if procs[0].GetPosition() != "append" {
-		t.Errorf("expected append position from workspace override, got %q", procs[0].GetPosition())
+	if procs[0].GetMutate() != "append" {
+		t.Errorf("expected append mutate from workspace override, got %q", procs[0].GetMutate())
 	}
 }
 
@@ -1626,7 +1842,10 @@ func TestCloneWithDirProcessors_NonexistentDir(t *testing.T) {
 	writeYAML(t, globalDir, "global.yaml", `
 name: global-proc
 enabled: true
-when: all
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 text: "global"
 `)
 
@@ -1652,8 +1871,11 @@ func TestCloneWithDirProcessors_Priority(t *testing.T) {
 	writeYAML(t, globalDir, "high.yaml", `
 name: high-priority
 enabled: true
-when: all
+when:
+  on: userPrompt
+  match: all
 priority: 50
+mutate: prepend
 text: "high"
 `)
 
@@ -1661,8 +1883,11 @@ text: "high"
 	writeYAML(t, wsDir, "low.yaml", `
 name: low-priority
 enabled: true
-when: all
+when:
+  on: userPrompt
+  match: all
 priority: 10
+mutate: prepend
 text: "low"
 `)
 
@@ -1692,7 +1917,10 @@ func TestCloneWithDirProcessors_EmptyDirs(t *testing.T) {
 	writeYAML(t, globalDir, "global.yaml", `
 name: global
 enabled: true
-when: all
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 text: "global"
 `)
 
@@ -1760,7 +1988,9 @@ func TestLoaderPromptModeValidation(t *testing.T) {
 		dir := t.TempDir()
 		writeYAML(t, dir, "valid.yaml", `
 name: valid-prompt
-when: all
+when:
+  on: userPrompt
+  match: all
 prompt: "Use mitto_conversation_history to retrieve messages."
 `)
 		loader := NewLoader(dir, nil)
@@ -1780,7 +2010,9 @@ prompt: "Use mitto_conversation_history to retrieve messages."
 		dir := t.TempDir()
 		writeYAML(t, dir, "bad.yaml", `
 name: bad-proc
-when: all
+when:
+  on: userPrompt
+  match: all
 prompt: "Analyze this"
 command: /bin/echo
 `)
@@ -1798,7 +2030,9 @@ command: /bin/echo
 		dir := t.TempDir()
 		writeYAML(t, dir, "bad.yaml", `
 name: bad-proc
-when: all
+when:
+  on: userPrompt
+  match: all
 prompt: "Analyze this"
 text: "some text"
 `)
@@ -1818,7 +2052,7 @@ func TestManagerRoutesPromptModeToApplyWithRerun(t *testing.T) {
 	mgr.processors = []*Processor{
 		{
 			Name:   "test-prompt",
-			When:   config.ProcessorWhenAll,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Prompt: "Analyze the session @mitto:session_id",
 		},
 	}
@@ -1861,7 +2095,7 @@ func TestPromptModeSingleNotBatched(t *testing.T) {
 	mgr.processors = []*Processor{
 		{
 			Name:   "solo-proc",
-			When:   config.ProcessorWhenAll,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Prompt: "Solo prompt",
 		},
 	}
@@ -1914,12 +2148,12 @@ func TestPromptModeBatching(t *testing.T) {
 	mgr.processors = []*Processor{
 		{
 			Name:   "proc-alpha",
-			When:   config.ProcessorWhenAll,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Prompt: "Alpha task prompt",
 		},
 		{
 			Name:   "proc-beta",
-			When:   config.ProcessorWhenAll,
+			When:   WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
 			Prompt: "Beta task prompt",
 		},
 	}
@@ -1988,4 +2222,747 @@ func writeYAML(t *testing.T, dir, filename, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write %s: %v", path, err)
 	}
+}
+
+// makeAfterInput returns a minimal AfterProcessorInput for tests.
+// SessionDir is set to a stable key so the MemoryStateStore injected by
+// makeAfterManager shares state across successive calls within the same test.
+func makeAfterInput(origin, stopReason string) AfterProcessorInput {
+	return AfterProcessorInput{
+		SessionID:     "test-session",
+		SessionDir:    "test-session-dir", // key for MemoryStateStore
+		Origin:        origin,
+		StopReason:    stopReason,
+		UserPrompt:    "hello",
+		AgentMessages: []string{"world"},
+		StartedAt:     time.Now().Add(-time.Second),
+		EndedAt:       time.Now(),
+	}
+}
+
+// makeAfterManager returns a Manager with no processors directory, using the
+// given processors slice directly (bypasses the filesystem loader).
+// A MemoryStateStore is injected so match:first / cadence state is preserved
+// across successive ApplyAfter calls within the same test.
+func makeAfterManager(procs []*Processor) *Manager {
+	m := NewManager("", nil)
+	m.processors = procs
+	m.SetStateStore(NewMemoryStateStore())
+	return m
+}
+
+// TestApplyAfter_EmptyPipeline verifies that an empty processor list returns
+// a zero-value ApplyAfterResult without panicking.
+func TestApplyAfter_EmptyPipeline(t *testing.T) {
+	m := makeAfterManager(nil)
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+	if len(result.Notifications) != 0 || len(result.ActionButtons) != 0 ||
+		len(result.UserDataPatch) != 0 || len(result.Errors) != 0 {
+		t.Errorf("expected empty result, got %+v", result)
+	}
+}
+
+// TestApplyAfter_SkipsUserPromptProcessors ensures userPrompt processors are ignored.
+func TestApplyAfter_SkipsUserPromptProcessors(t *testing.T) {
+	proc := &Processor{
+		Name:    "pre-phase",
+		When:    WhenConfig{On: PhaseUserPrompt, Match: MatchAll},
+		Command: "echo",
+		Output:  OutputDiscard,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors, got %v", result.Errors)
+	}
+}
+
+// TestApplyAfter_StopReasonFilter verifies that processors skip when the stop
+// reason does not match the processor's stopReasons list.
+func TestApplyAfter_StopReasonFilter(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "echo.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho done"), 0755)
+
+	proc := &Processor{
+		Name:    "end-turn-only",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputDiscard,
+	}
+	m := makeAfterManager([]*Processor{proc})
+
+	// Should fire for endTurn
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors for endTurn: %v", result.Errors)
+	}
+
+	// Should skip for maxTokens
+	result2 := m.ApplyAfter(context.Background(), makeAfterInput("user", "maxTokens"))
+	if len(result2.Errors) != 0 {
+		t.Errorf("unexpected errors for maxTokens: %v", result2.Errors)
+	}
+}
+
+// TestApplyAfter_OriginFilter verifies that excludeOrigins causes the processor
+// to be skipped when the origin matches.
+func TestApplyAfter_OriginFilter(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "echo.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho done"), 0755)
+
+	proc := &Processor{
+		Name:    "no-periodic",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}, ExcludeOrigins: []string{"periodic-runner"}},
+		Command: scriptPath,
+		Output:  OutputDiscard,
+	}
+	m := makeAfterManager([]*Processor{proc})
+
+	// Should skip for periodic-runner
+	result := m.ApplyAfter(context.Background(), makeAfterInput("periodic-runner", "end_turn"))
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors for excluded origin, got %v", result.Errors)
+	}
+
+	// Should fire for user
+	result2 := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+	if len(result2.Errors) != 0 {
+		t.Errorf("expected no errors for user origin, got %v", result2.Errors)
+	}
+}
+
+// TestApplyAfter_MatchFirst verifies that match:first fires exactly once.
+func TestApplyAfter_MatchFirst(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '{\"title\":\"hello\",\"message\":\"world\"}'"), 0755)
+
+	proc := &Processor{
+		Name:    "first-only",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchFirst, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	input := makeAfterInput("user", "end_turn")
+
+	// First call: fires
+	r1 := m.ApplyAfter(context.Background(), input)
+	if len(r1.Notifications) != 1 {
+		t.Fatalf("first call: expected 1 notification, got %d", len(r1.Notifications))
+	}
+
+	// Second call: must be skipped
+	r2 := m.ApplyAfter(context.Background(), input)
+	if len(r2.Notifications) != 0 {
+		t.Errorf("second call: expected 0 notifications (match=first), got %d", len(r2.Notifications))
+	}
+}
+
+// TestApplyAfter_MatchAllExceptFirst verifies that match:allExceptFirst skips the
+// first call and fires from the second onward.
+func TestApplyAfter_MatchAllExceptFirst(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '{\"title\":\"T\",\"message\":\"M\"}'"), 0755)
+
+	proc := &Processor{
+		Name:    "not-first",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAllExceptFirst, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	input := makeAfterInput("user", "end_turn")
+
+	// First call: skipped
+	r1 := m.ApplyAfter(context.Background(), input)
+	if len(r1.Notifications) != 0 {
+		t.Errorf("first call: expected 0 notifications, got %d", len(r1.Notifications))
+	}
+
+	// Second call: fires
+	r2 := m.ApplyAfter(context.Background(), input)
+	if len(r2.Notifications) != 1 {
+		t.Errorf("second call: expected 1 notification, got %d", len(r2.Notifications))
+	}
+}
+
+// TestApplyAfter_OutputDiscard verifies that output:discard runs the command but
+// produces no entries in the result.
+func TestApplyAfter_OutputDiscard(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "side_effect.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho 'should be discarded'"), 0755)
+
+	proc := &Processor{
+		Name:    "side-effect",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputDiscard,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.Notifications) != 0 || len(result.ActionButtons) != 0 ||
+		len(result.UserDataPatch) != 0 || len(result.Errors) != 0 {
+		t.Errorf("expected empty result for discard, got %+v", result)
+	}
+}
+
+// TestApplyAfter_OutputNotify_JSON verifies JSON-form notify output is parsed correctly.
+func TestApplyAfter_OutputNotify_JSON(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '{"title":"Alert","message":"Done","style":"success"}'`), 0755)
+
+	proc := &Processor{
+		Name:    "json-notify",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.Notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(result.Notifications))
+	}
+	n := result.Notifications[0]
+	if n.Title != "Alert" || n.Message != "Done" || n.Style != "success" {
+		t.Errorf("unexpected notification: %+v", n)
+	}
+}
+
+// TestApplyAfter_OutputNotify_PlainText verifies plain-text notify output.
+func TestApplyAfter_OutputNotify_PlainText(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'Title Line\nBody text here'"), 0755)
+
+	proc := &Processor{
+		Name:    "text-notify",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.Notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(result.Notifications))
+	}
+	n := result.Notifications[0]
+	if n.Title != "Title Line" {
+		t.Errorf("expected title 'Title Line', got %q", n.Title)
+	}
+	if n.Style != "info" {
+		t.Errorf("expected style 'info', got %q", n.Style)
+	}
+}
+
+// TestApplyAfter_OutputActionButtons_Array verifies JSON array form.
+func TestApplyAfter_OutputActionButtons_Array(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "buttons.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '[{"label":"Run tests","prompt":"Run tests now"},{"label":"Deploy","prompt":"Deploy to prod"}]'`), 0755)
+
+	proc := &Processor{
+		Name:    "array-buttons",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputActionButtons,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.ActionButtons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(result.ActionButtons))
+	}
+	if result.ActionButtons[0].Label != "Run tests" {
+		t.Errorf("expected label 'Run tests', got %q", result.ActionButtons[0].Label)
+	}
+}
+
+// TestApplyAfter_OutputActionButtons_SingleObject verifies single-object form.
+func TestApplyAfter_OutputActionButtons_SingleObject(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "button.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '{"label":"Deploy","prompt":"Deploy now"}'`), 0755)
+
+	proc := &Processor{
+		Name:    "single-button",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputActionButtons,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.ActionButtons) != 1 {
+		t.Fatalf("expected 1 button, got %d", len(result.ActionButtons))
+	}
+	if result.ActionButtons[0].Label != "Deploy" {
+		t.Errorf("expected label 'Deploy', got %q", result.ActionButtons[0].Label)
+	}
+}
+
+// TestApplyAfter_OutputUserData verifies that multiple processors' patches are merged
+// and that later processors win on key collision.
+func TestApplyAfter_OutputUserData_Merge(t *testing.T) {
+	dir := t.TempDir()
+	script1 := filepath.Join(dir, "ud1.sh")
+	script2 := filepath.Join(dir, "ud2.sh")
+	os.WriteFile(script1, []byte(`#!/bin/sh
+printf '{"lang":"go","version":"1.0"}'`), 0755)
+	os.WriteFile(script2, []byte(`#!/bin/sh
+printf '{"version":"2.0","extra":"yes"}'`), 0755)
+
+	proc1 := &Processor{
+		Name:    "ud1",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: script1,
+		Output:  OutputUserData,
+	}
+	proc2 := &Processor{
+		Name:    "ud2",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: script2,
+		Output:  OutputUserData,
+	}
+	m := makeAfterManager([]*Processor{proc1, proc2})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if result.UserDataPatch["lang"] != "go" {
+		t.Errorf("expected lang=go, got %q", result.UserDataPatch["lang"])
+	}
+	// proc2 overrides version
+	if result.UserDataPatch["version"] != "2.0" {
+		t.Errorf("expected version=2.0 (proc2 wins), got %q", result.UserDataPatch["version"])
+	}
+	if result.UserDataPatch["extra"] != "yes" {
+		t.Errorf("expected extra=yes, got %q", result.UserDataPatch["extra"])
+	}
+}
+
+// TestApplyAfter_CommandFailure verifies that a failing command records a non-fatal
+// error and that later processors still run.
+func TestApplyAfter_CommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	failScript := filepath.Join(dir, "fail.sh")
+	succScript := filepath.Join(dir, "succ.sh")
+	os.WriteFile(failScript, []byte("#!/bin/sh\nexit 1"), 0755)
+	os.WriteFile(succScript, []byte(`#!/bin/sh
+printf '{"title":"OK","message":"ran"}'`), 0755)
+
+	proc1 := &Processor{
+		Name:    "will-fail",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: failScript,
+		Output:  OutputDiscard,
+	}
+	proc2 := &Processor{
+		Name:    "will-succeed",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: succScript,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc1, proc2})
+	result := m.ApplyAfter(context.Background(), makeAfterInput("user", "end_turn"))
+
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error (from will-fail), got %d: %v", len(result.Errors), result.Errors)
+	}
+	if result.Errors[0].ProcessorName != "will-fail" {
+		t.Errorf("expected error from 'will-fail', got %q", result.Errors[0].ProcessorName)
+	}
+	if len(result.Notifications) != 1 {
+		t.Errorf("expected 1 notification from will-succeed, got %d", len(result.Notifications))
+	}
+}
+
+// TestApplyAfter_StdinPayload verifies that the JSON stdin payload contains expected fields.
+func TestApplyAfter_StdinPayload(t *testing.T) {
+	dir := t.TempDir()
+	// Read stdin and emit it as-is so we can inspect it via parseNotifyOutput hack
+	captureScript := filepath.Join(dir, "capture.sh")
+	outFile := filepath.Join(dir, "stdin.json")
+	script := fmt.Sprintf("#!/bin/sh\ncat > %s\nprintf '{\"title\":\"ok\",\"message\":\"done\"}'", outFile)
+	os.WriteFile(captureScript, []byte(script), 0755)
+
+	proc := &Processor{
+		Name:    "capture",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Command: captureScript,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+
+	input := AfterProcessorInput{
+		SessionID:     "sess-abc",
+		Origin:        "user",
+		StopReason:    "end_turn",
+		UserPrompt:    "hello world",
+		AgentMessages: []string{"response text"},
+		StartedAt:     time.Now().Add(-time.Second),
+		EndedAt:       time.Now(),
+	}
+	result := m.ApplyAfter(context.Background(), input)
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("failed to read captured stdin: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"sessionId":"sess-abc"`) {
+		t.Errorf("stdin JSON missing sessionId, got: %s", string(data))
+	}
+	if !strings.Contains(string(data), `"origin":"user"`) {
+		t.Errorf("stdin JSON missing origin, got: %s", string(data))
+	}
+	if !strings.Contains(string(data), `"stopReason":"end_turn"`) {
+		t.Errorf("stdin JSON missing stopReason, got: %s", string(data))
+	}
+	if !strings.Contains(string(data), `"userPrompt":"hello world"`) {
+		t.Errorf("stdin JSON missing userPrompt, got: %s", string(data))
+	}
+}
+
+// TestParseNotifyOutput tests the notify output parser in isolation.
+func TestParseNotifyOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantLen   int
+		wantTitle string
+		wantStyle string
+	}{
+		{"empty", "", 0, "", ""},
+		{"json full", `{"title":"T","message":"M","style":"warning"}`, 1, "T", "warning"},
+		{"json default style", `{"title":"T","message":"M"}`, 1, "T", "info"},
+		{"plain text single line", "Hello there", 1, "Hello there", "info"},
+		{"plain text multi line", "Title\nBody text", 1, "Title", "info"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNotifyOutput(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("expected %d notifications, got %d", tt.wantLen, len(got))
+			}
+			if tt.wantLen > 0 {
+				if got[0].Title != tt.wantTitle {
+					t.Errorf("title: got %q, want %q", got[0].Title, tt.wantTitle)
+				}
+				if got[0].Style != tt.wantStyle {
+					t.Errorf("style: got %q, want %q", got[0].Style, tt.wantStyle)
+				}
+			}
+		})
+	}
+}
+
+// TestParseActionButtonsOutput tests the actionButtons output parser in isolation.
+func TestParseActionButtonsOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int
+		wantErr bool
+	}{
+		{"empty", "", 0, false},
+		{"array", `[{"label":"A","prompt":"a"},{"label":"B","prompt":"b"}]`, 2, false},
+		{"single object", `{"label":"X","prompt":"x"}`, 1, false},
+		{"invalid json", `not json`, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseActionButtonsOutput(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(got) != tt.wantLen {
+				t.Errorf("expected %d buttons, got %d", tt.wantLen, len(got))
+			}
+		})
+	}
+}
+
+// TestParseUserDataOutput tests the userData output parser in isolation.
+func TestParseUserDataOutput(t *testing.T) {
+	got, err := parseUserDataOutput(`{"key":"val","other":"42"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["key"] != "val" || got["other"] != "42" {
+		t.Errorf("unexpected patch: %v", got)
+	}
+
+	_, err = parseUserDataOutput(`not json`)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+
+	got2, err := parseUserDataOutput("")
+	if err != nil || len(got2) != 0 {
+		t.Errorf("expected nil result for empty input, got %v %v", got2, err)
+	}
+}
+
+// TestApplyAfter_PromptMode verifies that a prompt-mode processor renders
+// its template with after-phase variables and parses the result as notify output.
+func TestApplyAfter_PromptMode_Notify(t *testing.T) {
+	proc := &Processor{
+		Name:   "prompt-notifier",
+		When:   WhenConfig{On: PhaseAgentResponded, Match: MatchAll, StopReasons: []string{"end_turn"}},
+		Prompt: `{"title":"Stop: @mitto:stop_reason","message":"Origin: @mitto:origin"}`,
+		Output: OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	input := makeAfterInput("user", "end_turn")
+	result := m.ApplyAfter(context.Background(), input)
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(result.Notifications))
+	}
+	n := result.Notifications[0]
+	if n.Title != "Stop: end_turn" {
+		t.Errorf("expected 'Stop: end_turn', got %q", n.Title)
+	}
+	if n.Message != "Origin: user" {
+		t.Errorf("expected 'Origin: user', got %q", n.Message)
+	}
+}
+
+// TestApplyAfter_Cadence_EveryNTurns verifies that a processor with
+// cadence.everyNTurns:2 fires on every 2nd turn (turns 2, 4, 6, ...).
+// Pre-increment semantics: TurnsSinceLastFire is incremented before the gate
+// check, so everyNTurns:2 means "fire when TurnsSinceLastFire reaches 2".
+func TestApplyAfter_Cadence_EveryNTurns(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '{"title":"cadence","message":"fired"}'`), 0755)
+
+	proc := &Processor{
+		Name: "cadenced",
+		When: WhenConfig{
+			On:          PhaseAgentResponded,
+			Match:       MatchAll,
+			StopReasons: []string{"end_turn"},
+			Cadence:     &CadenceConfig{EveryNTurns: 2},
+		},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+	m := makeAfterManager([]*Processor{proc})
+	input := makeAfterInput("user", "end_turn")
+
+	// Turn 1: pre-increment→1; 1 < 2 → skip
+	r1 := m.ApplyAfter(context.Background(), input)
+	if len(r1.Notifications) != 0 {
+		t.Errorf("turn 1: expected 0 notifications (cadence not yet met), got %d", len(r1.Notifications))
+	}
+
+	// Turn 2: pre-increment→2; 2 >= 2 → fires! reset to 0
+	r2 := m.ApplyAfter(context.Background(), input)
+	if len(r2.Notifications) != 1 {
+		t.Errorf("turn 2: expected 1 notification (cadence met), got %d", len(r2.Notifications))
+	}
+
+	// Turn 3: pre-increment→1; 1 < 2 → skip
+	r3 := m.ApplyAfter(context.Background(), input)
+	if len(r3.Notifications) != 0 {
+		t.Errorf("turn 3: expected 0 notifications (cadence not yet met), got %d", len(r3.Notifications))
+	}
+
+	// Turn 4: pre-increment→2; 2 >= 2 → fires again
+	r4 := m.ApplyAfter(context.Background(), input)
+	if len(r4.Notifications) != 1 {
+		t.Errorf("turn 4: expected 1 notification (cadence met), got %d", len(r4.Notifications))
+	}
+
+	// Turn 5: pre-increment→1; 1 < 2 → skip
+	r5 := m.ApplyAfter(context.Background(), input)
+	if len(r5.Notifications) != 0 {
+		t.Errorf("turn 5: expected 0 notifications (cadence not yet met), got %d", len(r5.Notifications))
+	}
+}
+
+// TestApplyAfter_Cadence_AfterInterval verifies that a processor with
+// cadence.afterInterval fires only after the specified duration has passed.
+func TestApplyAfter_Cadence_AfterInterval(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '{"title":"interval","message":"fired"}'`), 0755)
+
+	proc := &Processor{
+		Name: "interval-proc",
+		When: WhenConfig{
+			On:          PhaseAgentResponded,
+			Match:       MatchAll,
+			StopReasons: []string{"end_turn"},
+			Cadence:     &CadenceConfig{AfterInterval: "1h"},
+		},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+
+	// Use a controllable clock.
+	fakeNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	m := makeAfterManager([]*Processor{proc})
+	m.SetClock(func() time.Time { return fakeNow })
+	input := makeAfterInput("user", "end_turn")
+
+	// Turn 1: LastFiredAt is zero → interval threshold is skipped (nil time) → fires on first call
+	r1 := m.ApplyAfter(context.Background(), input)
+	if len(r1.Notifications) != 1 {
+		t.Errorf("turn 1 (first ever): expected 1 notification (never fired before), got %d", len(r1.Notifications))
+	}
+
+	// Turn 2: only 0 seconds elapsed → interval not met → skip
+	r2 := m.ApplyAfter(context.Background(), input)
+	if len(r2.Notifications) != 0 {
+		t.Errorf("turn 2: expected 0 notifications (interval not elapsed), got %d", len(r2.Notifications))
+	}
+
+	// Advance clock by 2 hours
+	fakeNow = fakeNow.Add(2 * time.Hour)
+	m.SetClock(func() time.Time { return fakeNow })
+
+	// Turn 3: 2h elapsed, threshold is 1h → fires
+	r3 := m.ApplyAfter(context.Background(), input)
+	if len(r3.Notifications) != 1 {
+		t.Errorf("turn 3: expected 1 notification (interval elapsed), got %d", len(r3.Notifications))
+	}
+}
+
+// TestApplyAfter_StatePersistence_MatchFirst verifies that match:first semantics
+// survive a manager restart by using a shared MemoryStateStore.
+func TestApplyAfter_StatePersistence_MatchFirst(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "notify.sh")
+	os.WriteFile(scriptPath, []byte(`#!/bin/sh
+printf '{"title":"first","message":"only once"}'`), 0755)
+
+	proc := &Processor{
+		Name:    "first-ever",
+		When:    WhenConfig{On: PhaseAgentResponded, Match: MatchFirst, StopReasons: []string{"end_turn"}},
+		Command: scriptPath,
+		Output:  OutputNotify,
+	}
+
+	// Shared store simulates persistence across two Manager instances.
+	shared := NewMemoryStateStore()
+	input := makeAfterInput("user", "end_turn")
+
+	// Session 1: first manager instance fires the processor.
+	m1 := NewManager("", nil)
+	m1.processors = []*Processor{proc}
+	m1.SetStateStore(shared)
+	r1 := m1.ApplyAfter(context.Background(), input)
+	if len(r1.Notifications) != 1 {
+		t.Fatalf("session 1: expected 1 notification, got %d", len(r1.Notifications))
+	}
+
+	// Session 2: new manager instance — but same shared store.
+	// Should NOT fire because AgentResponseCount == 1 in the store.
+	m2 := NewManager("", nil)
+	m2.processors = []*Processor{proc}
+	m2.SetStateStore(shared)
+	r2 := m2.ApplyAfter(context.Background(), input)
+	if len(r2.Notifications) != 0 {
+		t.Errorf("session 2 (after restart): expected 0 notifications (match=first already fired), got %d", len(r2.Notifications))
+	}
+}
+
+// TestCadenceConfig_Validation verifies that invalid cadence configurations
+// are rejected by the loader.
+func TestCadenceConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cadence *CadenceConfig
+		wantErr string
+	}{
+		{
+			name:    "no thresholds",
+			cadence: &CadenceConfig{},
+			wantErr: "at least one of",
+		},
+		{
+			name:    "negative everyNTurns",
+			cadence: &CadenceConfig{EveryNTurns: -1},
+			wantErr: "everyNTurns",
+		},
+		{
+			name:    "negative everyNTokens",
+			cadence: &CadenceConfig{EveryNTokens: -1},
+			wantErr: "everyNTokens",
+		},
+		{
+			name:    "invalid duration",
+			cadence: &CadenceConfig{AfterInterval: "not-a-duration"},
+			wantErr: "afterInterval",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlContent := buildProcessorYAML(tt.cadence)
+			tmpDir := t.TempDir()
+			f, _ := os.CreateTemp(tmpDir, "*.yaml")
+			f.WriteString(yamlContent)
+			f.Close()
+			loader := NewLoader(tmpDir, nil)
+			_, err := loader.LoadFile(f.Name())
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// buildProcessorYAML builds a minimal processor YAML with the given cadence config for testing.
+// When cadence is non-nil, ALL fields are always written (including zeros) so the YAML
+// parser sees an explicit cadence block (not null). This lets us test validation of
+// configurations that have cadence present but all thresholds at zero.
+func buildProcessorYAML(cadence *CadenceConfig) string {
+	var sb strings.Builder
+	sb.WriteString("name: test-cadence\n")
+	sb.WriteString("command: /bin/true\n")
+	sb.WriteString("when:\n")
+	sb.WriteString("  on: agentResponded\n")
+	sb.WriteString("  match: all\n")
+	if cadence != nil {
+		sb.WriteString("  cadence:\n")
+		// Always write all fields explicitly so the block is not parsed as null.
+		sb.WriteString(fmt.Sprintf("    everyNTurns: %d\n", cadence.EveryNTurns))
+		sb.WriteString(fmt.Sprintf("    everyNTokens: %d\n", cadence.EveryNTokens))
+		if cadence.AfterInterval != "" {
+			sb.WriteString(fmt.Sprintf("    afterInterval: %q\n", cadence.AfterInterval))
+		} else {
+			sb.WriteString("    afterInterval: \"\"\n")
+		}
+	}
+	return sb.String()
 }

--- a/internal/processors/processors_test.go
+++ b/internal/processors/processors_test.go
@@ -2956,10 +2956,10 @@ func buildProcessorYAML(cadence *CadenceConfig) string {
 	if cadence != nil {
 		sb.WriteString("  cadence:\n")
 		// Always write all fields explicitly so the block is not parsed as null.
-		sb.WriteString(fmt.Sprintf("    everyNTurns: %d\n", cadence.EveryNTurns))
-		sb.WriteString(fmt.Sprintf("    everyNTokens: %d\n", cadence.EveryNTokens))
+		fmt.Fprintf(&sb, "    everyNTurns: %d\n", cadence.EveryNTurns)
+		fmt.Fprintf(&sb, "    everyNTokens: %d\n", cadence.EveryNTokens)
 		if cadence.AfterInterval != "" {
-			sb.WriteString(fmt.Sprintf("    afterInterval: %q\n", cadence.AfterInterval))
+			fmt.Fprintf(&sb, "    afterInterval: %q\n", cadence.AfterInterval)
 		} else {
 			sb.WriteString("    afterInterval: \"\"\n")
 		}

--- a/internal/processors/state.go
+++ b/internal/processors/state.go
@@ -49,6 +49,9 @@ type StateStore interface {
 type FileStateStore struct{}
 
 func (s *FileStateStore) Load(sessionDir string) (*ProcessorStateData, error) {
+	if sessionDir == "" {
+		return &ProcessorStateData{Processors: make(map[string]*ProcessorCadenceState)}, nil
+	}
 	state := &ProcessorStateData{
 		Processors: make(map[string]*ProcessorCadenceState),
 	}
@@ -114,6 +117,9 @@ func copyState(src *ProcessorStateData) *ProcessorStateData {
 		Processors:         make(map[string]*ProcessorCadenceState, len(src.Processors)),
 	}
 	for k, v := range src.Processors {
+		if v == nil {
+			continue
+		}
 		cp := *v
 		dst.Processors[k] = &cp
 	}

--- a/internal/processors/state.go
+++ b/internal/processors/state.go
@@ -1,0 +1,121 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/inercia/mitto/internal/fileutil"
+)
+
+const processorStateFileName = "processor_state.json"
+
+// ProcessorCadenceState tracks cumulative counts for cadence throttling of one processor.
+// Counters are incremented every AgentResponded turn; reset whenever the processor fires.
+type ProcessorCadenceState struct {
+	// TurnsSinceLastFire is the number of AgentResponded turns since this processor last fired.
+	// Reset to 0 each time the processor fires.
+	TurnsSinceLastFire int `json:"turns_since_last_fire"`
+	// TokensSinceLastFire is the cumulative token count since this processor last fired.
+	// Reset to 0 each time the processor fires.
+	TokensSinceLastFire int64 `json:"tokens_since_last_fire"`
+	// LastFiredAt is when this processor last fired (zero if it has never fired).
+	LastFiredAt time.Time `json:"last_fired_at,omitempty"`
+}
+
+// ProcessorStateData is the JSON-serializable state for all processors in a session.
+// Stored in <session_dir>/processor_state.json.
+type ProcessorStateData struct {
+	// AgentResponseCount is the total number of ApplyAfter calls for this session.
+	// Used for match:first semantics: the processor runs only when count == 0.
+	AgentResponseCount int `json:"agent_response_count"`
+	// Processors maps processor name → its cadence state.
+	// Processors without cadence config do not appear here.
+	Processors map[string]*ProcessorCadenceState `json:"processors,omitempty"`
+}
+
+// StateStore is the interface for loading and saving processor state across session restarts.
+type StateStore interface {
+	// Load reads the persisted state for the given session directory.
+	// Returns a non-nil zero-value state if the file does not exist yet.
+	Load(sessionDir string) (*ProcessorStateData, error)
+	// Save atomically persists the state to the given session directory.
+	Save(sessionDir string, state *ProcessorStateData) error
+}
+
+// FileStateStore persists processor state in <session_dir>/processor_state.json.
+// It uses atomic writes to prevent corruption on crash.
+type FileStateStore struct{}
+
+func (s *FileStateStore) Load(sessionDir string) (*ProcessorStateData, error) {
+	state := &ProcessorStateData{
+		Processors: make(map[string]*ProcessorCadenceState),
+	}
+	path := filepath.Join(sessionDir, processorStateFileName)
+	err := fileutil.ReadJSON(path, state)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil // first run — return zero-value state
+		}
+		return nil, err
+	}
+	if state.Processors == nil {
+		state.Processors = make(map[string]*ProcessorCadenceState)
+	}
+	return state, nil
+}
+
+func (s *FileStateStore) Save(sessionDir string, state *ProcessorStateData) error {
+	if sessionDir == "" {
+		return nil // no-op if session dir is not configured (e.g., tests without persistence)
+	}
+	path := filepath.Join(sessionDir, processorStateFileName)
+	return fileutil.WriteJSONAtomic(path, state, 0644)
+}
+
+// MemoryStateStore is a non-persistent in-memory state store for testing.
+// It stores state keyed by sessionDir string.
+type MemoryStateStore struct {
+	mu    sync.Mutex
+	store map[string]*ProcessorStateData
+}
+
+// NewMemoryStateStore creates a new empty MemoryStateStore.
+func NewMemoryStateStore() *MemoryStateStore {
+	return &MemoryStateStore{store: make(map[string]*ProcessorStateData)}
+}
+
+func (s *MemoryStateStore) Load(sessionDir string) (*ProcessorStateData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.store[sessionDir]
+	if !ok {
+		return &ProcessorStateData{Processors: make(map[string]*ProcessorCadenceState)}, nil
+	}
+	// Return a deep copy to avoid races.
+	return copyState(state), nil
+}
+
+func (s *MemoryStateStore) Save(sessionDir string, state *ProcessorStateData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.store[sessionDir] = copyState(state)
+	return nil
+}
+
+// copyState returns a deep copy of a ProcessorStateData.
+func copyState(src *ProcessorStateData) *ProcessorStateData {
+	if src == nil {
+		return &ProcessorStateData{Processors: make(map[string]*ProcessorCadenceState)}
+	}
+	dst := &ProcessorStateData{
+		AgentResponseCount: src.AgentResponseCount,
+		Processors:         make(map[string]*ProcessorCadenceState, len(src.Processors)),
+	}
+	for k, v := range src.Processors {
+		cp := *v
+		dst.Processors[k] = &cp
+	}
+	return dst
+}

--- a/internal/processors/types.go
+++ b/internal/processors/types.go
@@ -245,7 +245,7 @@ type Processor struct {
 	Source ProcessorSource `yaml:"-" json:"source,omitempty"`
 }
 
-// RerunConfig configures automatic re-run for "when.sent: first" processors.
+// RerunConfig configures automatic re-run for "when.match: first" processors.
 type RerunConfig struct {
 	// AfterTime is the duration after which the processor should re-run.
 	// Supports Go duration strings: "10m", "1h", "30s", "2h30m".
@@ -343,7 +343,7 @@ type AfterProcessorInput struct {
 	SessionDir string `json:"-"`
 	// WorkingDir is the session's working directory (used for WorkingDirSession processors).
 	WorkingDir string `json:"workingDir,omitempty"`
-	// Origin is the source of the prompt: "user", "queue", "periodic-runner", "mcp-send-prompt".
+	// Origin is the source of the prompt: "user", "queue", or "periodic-runner".
 	Origin string `json:"origin"`
 	// StopReason is the ACP stop reason string (e.g. "end_turn", "max_tokens").
 	// These match the ACP SDK StopReason constants (snake_case).

--- a/internal/processors/types.go
+++ b/internal/processors/types.go
@@ -40,6 +40,16 @@ const (
 	OutputAppend OutputType = "append"
 	// OutputDiscard ignores stdout (side-effect only).
 	OutputDiscard OutputType = "discard"
+
+	// OutputNotify parses stdout as a UI notification (agentResponded phase only).
+	// Accepts JSON {"title","message","style"} or plain text (first line = title).
+	OutputNotify OutputType = "notify"
+	// OutputActionButtons parses stdout as follow-up action buttons (agentResponded phase only).
+	// Accepts JSON array [{label,prompt},...] or a single object.
+	OutputActionButtons OutputType = "actionButtons"
+	// OutputUserData parses stdout as user-data key→value patch (agentResponded phase only).
+	// Accepts JSON object of string→string entries.
+	OutputUserData OutputType = "userData"
 )
 
 // WorkingDirType defines the working directory for processor execution.
@@ -92,6 +102,86 @@ const (
 // (fire-and-forget). Returns error only if the prompt couldn't be dispatched.
 type PromptFunc func(ctx context.Context, workspaceUUID, processorName, prompt string) error
 
+// Phase defines when in the conversation lifecycle a processor fires.
+type Phase string
+
+const (
+	// PhaseUserPrompt fires processors before the user's message is sent to the ACP server.
+	PhaseUserPrompt Phase = "userPrompt"
+	// PhaseAgentResponded fires processors after the agent has finished responding.
+	// Only command-mode and prompt-mode processors are allowed for this phase.
+	PhaseAgentResponded Phase = "agentResponded"
+)
+
+// Match defines which messages in the sequence a processor applies to.
+type Match string
+
+const (
+	// MatchFirst applies only to the first-ever message in the conversation.
+	MatchFirst Match = "first"
+	// MatchAll applies to every message.
+	MatchAll Match = "all"
+	// MatchAllExceptFirst applies to all messages except the first.
+	MatchAllExceptFirst Match = "allExceptFirst"
+)
+
+// CadenceConfig throttles how often an agentResponded processor fires.
+// All specified thresholds must be met simultaneously (AND logic).
+// Only valid for when.on: agentResponded and when.match: all or allExceptFirst.
+//
+// Example:
+//
+//	when:
+//	  on:    agentResponded
+//	  match: all
+//	  cadence:
+//	    everyNTurns:  5      # fire every 5 agent responses
+//	    everyNTokens: 10000  # AND only after 10k cumulative tokens
+//	    afterInterval: 30m   # AND only if 30 minutes have passed
+type CadenceConfig struct {
+	// EveryNTurns fires the processor every N agent responses (1 = every turn).
+	// Must be ≥ 1 when specified.
+	EveryNTurns int `yaml:"everyNTurns,omitempty" json:"every_n_turns,omitempty"`
+	// EveryNTokens fires once N cumulative tokens have been used since the last firing.
+	// Must be ≥ 1 when specified.
+	EveryNTokens int64 `yaml:"everyNTokens,omitempty" json:"every_n_tokens,omitempty"`
+	// AfterInterval is the minimum wall-clock gap between firings (e.g. "5m", "1h").
+	// Uses Go duration syntax. Must be > 0 when specified.
+	AfterInterval string `yaml:"afterInterval,omitempty" json:"after_interval,omitempty"`
+}
+
+// GetAfterIntervalDuration parses the AfterInterval string into a time.Duration.
+// Returns 0 if the field is unset or unparseable.
+func (c *CadenceConfig) GetAfterIntervalDuration() time.Duration {
+	if c == nil || c.AfterInterval == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.AfterInterval)
+	if err != nil {
+		return 0
+	}
+	return d
+}
+
+// WhenConfig specifies when a processor triggers and optional rerun configuration.
+// Only the block form is accepted:
+//
+//	when:
+//	  on:    userPrompt | agentResponded   # required
+//	  match: first | all | allExceptFirst  # required
+//	  rerun:                               # optional; only valid with on:userPrompt + match:first
+//	    afterSentMsgs: 15
+//	  cadence:                             # optional; only valid with on:agentResponded + match:all or allExceptFirst
+//	    everyNTurns: 5
+type WhenConfig struct {
+	On             Phase          `yaml:"on" json:"on"`
+	Match          Match          `yaml:"match" json:"match"`
+	Rerun          *RerunConfig   `yaml:"rerun,omitempty" json:"rerun,omitempty"`
+	Cadence        *CadenceConfig `yaml:"cadence,omitempty" json:"cadence,omitempty"`
+	StopReasons    []string       `yaml:"stopReasons,omitempty" json:"stop_reasons,omitempty"`
+	ExcludeOrigins []string       `yaml:"excludeOrigins,omitempty" json:"exclude_origins,omitempty"`
+}
+
 // Processor represents a loaded processor definition.
 type Processor struct {
 	// Name is a human-readable identifier for the processor.
@@ -101,10 +191,10 @@ type Processor struct {
 	// Enabled controls whether the processor is active. Default: true.
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 
-	// When specifies when the processor triggers: "first", "all", "all-except-first".
-	When config.ProcessorWhen `yaml:"when" json:"when"`
-	// Position specifies where in the pipeline: "prepend" or "append".
-	Position config.ProcessorPosition `yaml:"position,omitempty" json:"position,omitempty"`
+	// When specifies when the processor triggers and optional rerun configuration.
+	When WhenConfig `yaml:"when" json:"when"`
+	// Mutate specifies where in the pipeline: "prepend" or "append".
+	Mutate config.ProcessorMutate `yaml:"mutate,omitempty" json:"mutate,omitempty"`
 	// Priority determines execution order (lower = earlier). Default: 100.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
@@ -140,13 +230,6 @@ type Processor struct {
 	// OnError defines error handling: "skip" or "fail". Default: "skip".
 	OnError ErrorHandling `yaml:"on_error,omitempty" json:"on_error,omitempty"`
 
-	// Rerun configures automatic re-run for "when: first" processors.
-	// Allows a first-only processor to fire again after a time interval or message count,
-	// refreshing context for the LLM. Only used with when: first.
-	// If both AfterTime, AfterSentMsgs, and AfterTokens are set, whichever threshold is reached first
-	// triggers the re-run.
-	Rerun *RerunConfig `yaml:"rerun,omitempty" json:"rerun,omitempty"`
-
 	// EnabledWhen is an optional CEL expression that determines whether this processor applies.
 	// Uses the same CEL context as prompt enabledWhen expressions (acp.*, session.*, parent.*,
 	// children.*, workspace.*, tools.*). If empty, the processor always applies (subject to
@@ -162,7 +245,7 @@ type Processor struct {
 	Source ProcessorSource `yaml:"-" json:"source,omitempty"`
 }
 
-// RerunConfig configures automatic re-run for "when: first" processors.
+// RerunConfig configures automatic re-run for "when.sent: first" processors.
 type RerunConfig struct {
 	// AfterTime is the duration after which the processor should re-run.
 	// Supports Go duration strings: "10m", "1h", "30s", "2h30m".
@@ -218,6 +301,11 @@ func (h *Processor) IsPromptMode() bool {
 	return h.Command == "" && h.Text == "" && h.Prompt != ""
 }
 
+// GetRerun returns the processor's rerun configuration (from When.Rerun).
+func (p *Processor) GetRerun() *RerunConfig {
+	return p.When.Rerun
+}
+
 // Duration is a wrapper for time.Duration that supports YAML unmarshaling.
 type Duration time.Duration
 
@@ -242,4 +330,84 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Duration returns the time.Duration value.
 func (d Duration) Duration() time.Duration {
 	return time.Duration(d)
+}
+
+// AfterProcessorInput captures the agent's completed turn for agentResponded processors.
+// Fields are serialized to JSON (camelCase) for the processor's stdin payload.
+// SessionDir is excluded from JSON serialization — it is used internally for state persistence.
+type AfterProcessorInput struct {
+	// SessionID is the current session identifier.
+	SessionID string `json:"sessionId"`
+	// SessionDir is the on-disk directory for this session (used for processor state persistence).
+	// This field is NOT serialized to JSON — it is for internal use only.
+	SessionDir string `json:"-"`
+	// WorkingDir is the session's working directory (used for WorkingDirSession processors).
+	WorkingDir string `json:"workingDir,omitempty"`
+	// Origin is the source of the prompt: "user", "queue", "periodic-runner", "mcp-send-prompt".
+	Origin string `json:"origin"`
+	// StopReason is the ACP stop reason string (e.g. "end_turn", "max_tokens").
+	// These match the ACP SDK StopReason constants (snake_case).
+	StopReason string `json:"stopReason"`
+	// UserPrompt is the text of the user prompt that triggered this turn.
+	UserPrompt string `json:"userPrompt"`
+	// AgentMessages contains the concatenated text chunks from the agent's response.
+	AgentMessages []string `json:"agentMessages"`
+	// ToolCalls contains lightweight snapshots of tool calls made during the turn.
+	ToolCalls []AfterToolCallSnapshot `json:"toolCalls"`
+	// TokenUsage reports token consumption for the turn (may be nil if not reported).
+	TokenUsage *AfterTokenUsage `json:"tokenUsage,omitempty"`
+	// StartedAt is when the prompt was sent to the agent.
+	StartedAt time.Time `json:"startedAt"`
+	// EndedAt is when the agent's response was fully received.
+	EndedAt time.Time `json:"endedAt"`
+}
+
+// AfterToolCallSnapshot is a lightweight snapshot of one tool call from an agent turn.
+type AfterToolCallSnapshot struct {
+	Name   string `json:"name"`
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Title  string `json:"title"`
+}
+
+// AfterTokenUsage captures token consumption for the agent's turn.
+type AfterTokenUsage struct {
+	Input  int64 `json:"input"`
+	Output int64 `json:"output"`
+	Total  int64 `json:"total"`
+}
+
+// ApplyAfterResult contains the aggregated side-effects from all agentResponded processors.
+// BackgroundSession (Task 4) consumes this to trigger UI notifications, enqueue action
+// buttons, and patch workspace user_data.
+type ApplyAfterResult struct {
+	// Notifications collects entries from processors with output: notify.
+	Notifications []AfterNotification `json:"notifications,omitempty"`
+	// ActionButtons collects entries from processors with output: actionButtons.
+	ActionButtons []AfterActionButton `json:"actionButtons,omitempty"`
+	// UserDataPatch is the merged key→value patch from processors with output: userData.
+	// Later processors override earlier ones on key collision.
+	UserDataPatch map[string]string `json:"userDataPatch,omitempty"`
+	// Errors holds non-fatal errors. A failing processor does not block later processors.
+	Errors []ProcessorError `json:"errors,omitempty"`
+}
+
+// AfterNotification is a UI notification produced by an agentResponded processor.
+type AfterNotification struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
+	// Style is one of "info", "success", "warning", "error". Defaults to "info".
+	Style string `json:"style,omitempty"`
+}
+
+// AfterActionButton is a suggested follow-up action produced by an agentResponded processor.
+type AfterActionButton struct {
+	Label  string `json:"label"`
+	Prompt string `json:"prompt"`
+}
+
+// ProcessorError records a non-fatal error from a single processor in the after-phase pipeline.
+type ProcessorError struct {
+	ProcessorName string `json:"processorName"`
+	Error         string `json:"error"`
 }

--- a/internal/session/periodic.go
+++ b/internal/session/periodic.go
@@ -99,6 +99,10 @@ func (f *Frequency) Duration() time.Duration {
 type PeriodicPrompt struct {
 	// Prompt is the message text to send.
 	Prompt string `json:"prompt"`
+	// PromptName is the name of a workspace prompt to resolve at execution time.
+	// When set, the prompt text is resolved from the workspace prompts at execution time.
+	// Either Prompt or PromptName must be set.
+	PromptName string `json:"prompt_name,omitempty"`
 	// Frequency defines how often the prompt should be sent.
 	Frequency Frequency `json:"frequency"`
 	// Enabled indicates whether the periodic prompt is active.
@@ -115,7 +119,7 @@ type PeriodicPrompt struct {
 
 // Validate checks if the periodic prompt configuration is valid.
 func (p *PeriodicPrompt) Validate() error {
-	if p.Prompt == "" {
+	if p.Prompt == "" && p.PromptName == "" {
 		return ErrPromptEmpty
 	}
 	return p.Frequency.Validate()
@@ -190,7 +194,7 @@ func (ps *PeriodicStore) Set(p *PeriodicPrompt) error {
 
 // Update applies a partial update to the periodic prompt.
 // Only non-nil fields in the update are applied.
-func (ps *PeriodicStore) Update(prompt *string, frequency *Frequency, enabled *bool) error {
+func (ps *PeriodicStore) Update(prompt *string, promptName *string, frequency *Frequency, enabled *bool) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
@@ -201,6 +205,9 @@ func (ps *PeriodicStore) Update(prompt *string, frequency *Frequency, enabled *b
 
 	if prompt != nil {
 		existing.Prompt = *prompt
+	}
+	if promptName != nil {
+		existing.PromptName = *promptName
 	}
 	if frequency != nil {
 		existing.Frequency = *frequency

--- a/internal/session/periodic_test.go
+++ b/internal/session/periodic_test.go
@@ -316,7 +316,7 @@ func TestPeriodicStore_Update(t *testing.T) {
 
 	// Update on non-existent should fail
 	enabled := true
-	err := ps.Update(nil, nil, &enabled)
+	err := ps.Update(nil, nil, nil, &enabled)
 	if err != ErrPeriodicNotFound {
 		t.Errorf("Update() on empty store error = %v, want ErrPeriodicNotFound", err)
 	}
@@ -333,7 +333,7 @@ func TestPeriodicStore_Update(t *testing.T) {
 
 	// Update only enabled field
 	disabled := false
-	if err := ps.Update(nil, nil, &disabled); err != nil {
+	if err := ps.Update(nil, nil, nil, &disabled); err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
 
@@ -347,7 +347,7 @@ func TestPeriodicStore_Update(t *testing.T) {
 
 	// Update only prompt field
 	newPrompt := "New prompt text"
-	if err := ps.Update(&newPrompt, nil, nil); err != nil {
+	if err := ps.Update(&newPrompt, nil, nil, nil); err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
 
@@ -358,7 +358,7 @@ func TestPeriodicStore_Update(t *testing.T) {
 
 	// Update frequency
 	newFreq := Frequency{Value: 30, Unit: FrequencyMinutes}
-	if err := ps.Update(nil, &newFreq, nil); err != nil {
+	if err := ps.Update(nil, nil, &newFreq, nil); err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
 
@@ -382,7 +382,7 @@ func TestPeriodicStore_UpdateValidation(t *testing.T) {
 
 	// Update with invalid frequency should fail (value must be >= 1)
 	invalidFreq := Frequency{Value: 0, Unit: FrequencyMinutes} // Zero not allowed
-	err := ps.Update(nil, &invalidFreq, nil)
+	err := ps.Update(nil, nil, &invalidFreq, nil)
 	if err == nil {
 		t.Error("Update() with invalid frequency should return error")
 	}
@@ -493,7 +493,7 @@ func TestPeriodicStore_NextScheduledAtWhenDisabled(t *testing.T) {
 
 	// Enable it
 	enabled := true
-	ps.Update(nil, nil, &enabled)
+	ps.Update(nil, nil, nil, &enabled)
 
 	got, _ = ps.Get()
 	if got.NextScheduledAt == nil {
@@ -502,7 +502,7 @@ func TestPeriodicStore_NextScheduledAtWhenDisabled(t *testing.T) {
 
 	// Disable again
 	disabled := false
-	ps.Update(nil, nil, &disabled)
+	ps.Update(nil, nil, nil, &disabled)
 
 	got, _ = ps.Get()
 	if got.NextScheduledAt != nil {

--- a/internal/web/background_session.go
+++ b/internal/web/background_session.go
@@ -188,6 +188,11 @@ type BackgroundSession struct {
 	lastUsage   *acp.Usage
 	lastUsageMu sync.Mutex
 
+	// Context window usage — updated from SessionUsageUpdate notifications.
+	contextSize    int
+	contextUsed    int
+	contextUsageMu sync.Mutex
+
 	// sharedProcess is set when this session uses workspace-scoped process sharing.
 	// When non-nil, this session does not own the OS process — it only owns a session
 	// slot on the shared process. nil = legacy per-session process ownership.
@@ -1352,6 +1357,27 @@ func (bs *BackgroundSession) GetLastUsage() *acp.Usage {
 	return bs.lastUsage
 }
 
+// GetContextUsage returns the last known context window usage.
+// Returns (0, 0) if no usage update has been received yet.
+// This method is thread-safe.
+func (bs *BackgroundSession) GetContextUsage() (size, used int) {
+	bs.contextUsageMu.Lock()
+	defer bs.contextUsageMu.Unlock()
+	return bs.contextSize, bs.contextUsed
+}
+
+// onContextUsageUpdate stores the latest context window usage and notifies all observers.
+func (bs *BackgroundSession) onContextUsageUpdate(size, used int) {
+	bs.contextUsageMu.Lock()
+	bs.contextSize = size
+	bs.contextUsed = used
+	bs.contextUsageMu.Unlock()
+
+	bs.notifyObservers(func(o SessionObserver) {
+		o.OnContextUsageUpdate(size, used)
+	})
+}
+
 // GetRestartStats returns statistics about ACP process restarts for telemetry.
 // This method is thread-safe.
 func (bs *BackgroundSession) GetRestartStats() RestartStats {
@@ -2205,6 +2231,7 @@ func (bs *BackgroundSession) buildWebClientConfig() WebClientConfig {
 		OnAvailableCommands:  bs.onAvailableCommands,
 		OnCurrentModeChanged: bs.onCurrentModeChanged,
 		OnMittoToolCall:      bs.onMittoToolCall,
+		OnContextUsageUpdate: bs.onContextUsageUpdate,
 	}
 	if bs.fileLinksConfig.IsEnabled() {
 		cfg.FileLinksConfig = &conversion.FileLinkerConfig{

--- a/internal/web/background_session.go
+++ b/internal/web/background_session.go
@@ -3108,6 +3108,7 @@ func (bs *BackgroundSession) PromptWithMeta(message string, meta PromptMeta) err
 
 		var promptResp acp.PromptResponse
 		var err error
+		promptStartedAt := time.Now() // captured for after-phase processors
 		if bs.sharedProcess != nil {
 			promptResp, err = bs.sharedProcess.Prompt(promptCtx, acp.SessionId(bs.acpID), finalBlocks)
 		} else {
@@ -3116,6 +3117,7 @@ func (bs *BackgroundSession) PromptWithMeta(message string, meta PromptMeta) err
 				Prompt:    finalBlocks,
 			})
 		}
+		promptEndedAt := time.Now() // captured for after-phase processors
 
 		// Store token usage from the prompt response (if available).
 		if promptResp.Usage != nil {
@@ -3316,6 +3318,14 @@ func (bs *BackgroundSession) PromptWithMeta(message string, meta PromptMeta) err
 					}
 				}
 			}
+
+			// Apply after-phase processors (on: agentResponded pipeline).
+			// Runs after follow-up analysis so all event state is fully persisted.
+			// This is synchronous — processors are fast (command execution with timeouts).
+			if bs.processorManager != nil {
+				bs.applyAfterProcessors(bs.ctx, message, meta.SenderID,
+					string(promptResp.StopReason), promptStartedAt, promptEndedAt, promptResp)
+			}
 		}
 
 		// Invoke OnComplete callback if set.
@@ -3427,6 +3437,197 @@ func (bs *BackgroundSession) analyzeFollowUpQuestions(userPrompt, agentMessage s
 	bs.notifyObservers(func(o SessionObserver) {
 		o.OnActionButtons(buttons)
 	})
+}
+
+// promptOriginFromSenderID maps a PromptMeta.SenderID to the canonical origin tag used
+// by after-phase processors in their excludeOrigins filter.
+//
+// Canonical origin strings (kept in sync with processors.AfterProcessorInput.Origin docs):
+//
+//	"user"             – direct user prompt from a WebSocket client
+//	"queue"            – message injected via the queue (includes mcp-send-prompt, which
+//	                     cannot be distinguished from regular queue messages at this layer)
+//	"periodic-runner"  – message sent by the periodic runner goroutine
+//
+// If a new origin is introduced (e.g. mcp-send-prompt queued with a dedicated SenderID),
+// add it here and update the AfterProcessorInput.Origin godoc in types.go.
+func promptOriginFromSenderID(senderID string) string {
+	switch senderID {
+	case "periodic-runner":
+		return "periodic-runner"
+	case "queue":
+		// Covers both direct queue messages and MCP mitto_conversation_send_prompt,
+		// which are indistinguishable at this layer (both use SenderID="queue").
+		// TODO: when mcp-send-prompt gets a dedicated SenderID, add a case here.
+		return "queue"
+	default:
+		// Empty SenderID (Prompt/PromptWithImages) or a WebSocket client UUID.
+		return "user"
+	}
+}
+
+// applyAfterProcessors runs the agentResponded processor pipeline after an ACP turn completes.
+// It is called synchronously in the prompt goroutine, after follow-up suggestion analysis,
+// so all events are already flushed and persisted at this point.
+//
+// Results are dispatched as follows:
+//   - Notifications → bs.UINotify (fire-and-forget toast)
+//   - ActionButtons → appended to the existing action-buttons cache/store and broadcast
+//   - UserDataPatch → merged into the session's user-data file
+//   - Errors        → logged as warnings (non-fatal)
+func (bs *BackgroundSession) applyAfterProcessors(
+	ctx context.Context,
+	userPrompt string,
+	senderID string,
+	stopReason string,
+	startedAt, endedAt time.Time,
+	promptResp acp.PromptResponse,
+) {
+	// Build agent messages from the last persisted agent message.
+	var agentMessages []string
+	if bs.store != nil {
+		if events, err := bs.store.ReadEvents(bs.persistedID); err == nil {
+			if msg := session.GetLastAgentMessage(events); msg != "" {
+				agentMessages = []string{msg}
+			}
+		}
+	}
+
+	// Build token usage snapshot (nil if ACP did not report usage).
+	var tokenUsage *processors.AfterTokenUsage
+	if promptResp.Usage != nil {
+		tokenUsage = &processors.AfterTokenUsage{
+			Input:  int64(promptResp.Usage.InputTokens),
+			Output: int64(promptResp.Usage.OutputTokens),
+			Total:  int64(promptResp.Usage.TotalTokens),
+		}
+	}
+
+	// Resolve session directory for processor state persistence (cadence + match:first).
+	var sessionDir string
+	if bs.store != nil && bs.persistedID != "" {
+		sessionDir = bs.store.SessionDir(bs.persistedID)
+	}
+
+	input := processors.AfterProcessorInput{
+		SessionID:     bs.persistedID,
+		SessionDir:    sessionDir,
+		WorkingDir:    bs.workingDir,
+		Origin:        promptOriginFromSenderID(senderID),
+		StopReason:    stopReason,
+		UserPrompt:    userPrompt,
+		AgentMessages: agentMessages,
+		ToolCalls:     nil, // TODO: populate from turn events in a future pass
+		TokenUsage:    tokenUsage,
+		StartedAt:     startedAt,
+		EndedAt:       endedAt,
+	}
+
+	result := bs.processorManager.ApplyAfter(ctx, input)
+
+	// Log non-fatal processor errors as warnings.
+	for _, pe := range result.Errors {
+		if bs.logger != nil {
+			bs.logger.Warn("after-phase processor error (non-fatal)",
+				"processor", pe.ProcessorName,
+				"error", pe.Error)
+		}
+	}
+
+	// Dispatch notifications via UINotify (uses OnNotification observer path).
+	for _, n := range result.Notifications {
+		req := UINotifyRequest{
+			Title:   n.Title,
+			Message: n.Message,
+			Style:   n.Style,
+		}
+		if err := bs.UINotify(req); err != nil && bs.logger != nil {
+			bs.logger.Warn("after-phase: failed to dispatch notification",
+				"title", n.Title,
+				"error", err)
+		}
+	}
+
+	// Append action buttons to the existing store and notify observers.
+	if len(result.ActionButtons) > 0 {
+		buttons := make([]ActionButton, 0, len(result.ActionButtons))
+		for _, ab := range result.ActionButtons {
+			buttons = append(buttons, ActionButton{
+				Label:    ab.Label,
+				Response: ab.Prompt,
+			})
+		}
+
+		// Merge with any existing cached buttons (e.g. from follow-up analysis).
+		bs.actionButtonsMu.Lock()
+		merged := make([]ActionButton, 0, len(bs.cachedActionButtons)+len(buttons))
+		merged = append(merged, bs.cachedActionButtons...)
+		merged = append(merged, buttons...)
+		bs.cachedActionButtons = merged
+		bs.actionButtonsMu.Unlock()
+
+		// Persist to disk.
+		if bs.store != nil && bs.persistedID != "" {
+			abStore := bs.store.ActionButtons(bs.persistedID)
+			sessionButtons := make([]session.ActionButton, len(merged))
+			for i, b := range merged {
+				sessionButtons[i] = session.ActionButton{Label: b.Label, Response: b.Response}
+			}
+			if err := abStore.Set(sessionButtons, int64(bs.GetEventCount())); err != nil && bs.logger != nil {
+				bs.logger.Debug("after-phase: failed to persist action buttons", "error", err)
+			}
+		}
+
+		bs.notifyObservers(func(o SessionObserver) {
+			o.OnActionButtons(merged)
+		})
+	}
+
+	// Merge UserDataPatch into the session's user-data file.
+	if len(result.UserDataPatch) > 0 && bs.store != nil && bs.persistedID != "" {
+		// Read current user data.
+		current, err := bs.store.GetUserData(bs.persistedID)
+		if err != nil {
+			if bs.logger != nil {
+				bs.logger.Warn("after-phase: failed to read user data for patch", "error", err)
+			}
+		} else {
+			// Build a name→value map of existing attributes for fast lookup.
+			attrMap := make(map[string]string, len(current.Attributes))
+			for _, a := range current.Attributes {
+				attrMap[a.Name] = a.Value
+			}
+			// Apply patch (later processors override earlier on key collision).
+			patchedKeys := 0
+			for k, v := range result.UserDataPatch {
+				attrMap[k] = v
+				patchedKeys++
+			}
+			// Reconstruct ordered slice: keep existing order, then append new keys.
+			newAttrs := make([]session.UserDataAttribute, 0, len(attrMap))
+			seen := make(map[string]bool)
+			for _, a := range current.Attributes {
+				newAttrs = append(newAttrs, session.UserDataAttribute{Name: a.Name, Value: attrMap[a.Name]})
+				seen[a.Name] = true
+			}
+			for k, v := range result.UserDataPatch {
+				if !seen[k] {
+					newAttrs = append(newAttrs, session.UserDataAttribute{Name: k, Value: v})
+				}
+			}
+			if err := bs.store.SetUserData(bs.persistedID, &session.UserData{Attributes: newAttrs}); err != nil {
+				if bs.logger != nil {
+					bs.logger.Warn("after-phase: failed to persist user data patch",
+						"patched_keys", patchedKeys,
+						"error", err)
+				}
+			} else if bs.logger != nil {
+				bs.logger.Debug("after-phase: user data patched",
+					"patched_keys", patchedKeys,
+					"total_keys", len(newAttrs))
+			}
+		}
+	}
 }
 
 // TriggerFollowUpSuggestions triggers follow-up suggestions analysis for a resumed session.

--- a/internal/web/background_session_test.go
+++ b/internal/web/background_session_test.go
@@ -358,6 +358,10 @@ func (m *mockSessionObserver) OnNotification(req UINotifyRequest) {
 	// no-op for testing
 }
 
+func (m *mockSessionObserver) OnContextUsageUpdate(size, used int) {
+	// no-op for testing
+}
+
 func (m *mockSessionObserver) getACPStoppedReasons() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1869,6 +1873,8 @@ func (o *trackingObserver) OnUIPromptDismiss(requestID string, reason string) {
 }
 
 func (o *trackingObserver) OnNotification(req UINotifyRequest) {}
+
+func (o *trackingObserver) OnContextUsageUpdate(size, used int) {}
 
 // =============================================================================
 // GetMaxAssignedSeq Tests

--- a/internal/web/client.go
+++ b/internal/web/client.go
@@ -47,6 +47,8 @@ type WebClient struct {
 	onCurrentModeChanged func(modeID string)
 	// onMittoToolCall is called when any mitto_* tool call is detected.
 	onMittoToolCall func(selfID string)
+	// onContextUsageUpdate is called when the agent sends a context window usage update.
+	onContextUsageUpdate func(size, used int)
 
 	// Stream buffer for all streaming events (markdown, thoughts, tool calls, etc.)
 	// This ensures correct ordering even when markdown content is buffered.
@@ -140,6 +142,8 @@ type WebClientConfig struct {
 	// The callback receives the self_id extracted from the tool call arguments.
 	// All mitto_* tools use self_id for automatic session detection.
 	OnMittoToolCall func(selfID string)
+	// OnContextUsageUpdate is called when the agent sends context window usage data.
+	OnContextUsageUpdate func(size, used int)
 	// FileLinksConfig configures file path detection and linking in agent messages.
 	// If nil, file linking is disabled.
 	FileLinksConfig *conversion.FileLinkerConfig
@@ -157,6 +161,7 @@ func NewWebClient(config WebClientConfig) *WebClient {
 		onAvailableCommands:  config.OnAvailableCommands,
 		onCurrentModeChanged: config.OnCurrentModeChanged,
 		onMittoToolCall:      config.OnMittoToolCall,
+		onContextUsageUpdate: config.OnContextUsageUpdate,
 	}
 
 	// Create stream buffer that handles all streaming events.
@@ -233,6 +238,8 @@ func (c *WebClient) SessionUpdate(ctx context.Context, params acp.SessionNotific
 		eventType = "available_commands"
 	case u.CurrentModeUpdate != nil:
 		eventType = "current_mode"
+	case u.UsageUpdate != nil:
+		eventType = "usage_update"
 	default:
 		eventType = "unknown"
 	}
@@ -333,6 +340,12 @@ func (c *WebClient) SessionUpdate(ctx context.Context, params acp.SessionNotific
 		// Current mode changed; notify immediately.
 		if c.onCurrentModeChanged != nil {
 			c.onCurrentModeChanged(string(u.CurrentModeUpdate.CurrentModeId))
+		}
+
+	case u.UsageUpdate != nil:
+		// Context window usage update; notify immediately.
+		if c.onContextUsageUpdate != nil {
+			c.onContextUsageUpdate(u.UsageUpdate.Size, u.UsageUpdate.Used)
 		}
 	}
 

--- a/internal/web/observer.go
+++ b/internal/web/observer.go
@@ -150,4 +150,8 @@ type SessionObserver interface {
 	// play a sound or show a native OS notification.
 	// Unlike OnUIPrompt, no response is expected from the observer.
 	OnNotification(req UINotifyRequest)
+
+	// OnContextUsageUpdate is called when the agent sends a context window usage update.
+	// size is the total context window size in tokens, used is how many tokens are currently in context.
+	OnContextUsageUpdate(size, used int)
 }

--- a/internal/web/observer_test.go
+++ b/internal/web/observer_test.go
@@ -108,6 +108,10 @@ func (m *mockObserver) OnNotification(req UINotifyRequest) {
 	// no-op for testing
 }
 
+func (m *mockObserver) OnContextUsageUpdate(size, used int) {
+	// no-op for testing
+}
+
 func TestSessionObserver_Interface(t *testing.T) {
 	// Verify mockObserver implements SessionObserver
 	var _ SessionObserver = (*mockObserver)(nil)

--- a/internal/web/periodic_runner.go
+++ b/internal/web/periodic_runner.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -35,6 +36,9 @@ type PeriodicStartedCallback func(sessionID, sessionName string)
 // It should handle broadcasting the archive state change and stopping ACP.
 type AutoArchiveCallback func(sessionID string)
 
+// PromptResolverFunc resolves a prompt name to its full text for a given working directory.
+type PromptResolverFunc func(promptName string, workingDir string) (string, error)
+
 // PeriodicRunner manages scheduled periodic prompt delivery and session housekeeping.
 // It polls all sessions at regular intervals and:
 // - Delivers periodic prompts that are due
@@ -60,6 +64,9 @@ type PeriodicRunner struct {
 	// archiveRetentionPeriod, when non-empty, causes archived sessions older than this
 	// to be permanently deleted during each poll cycle (not just at startup).
 	archiveRetentionPeriod string
+
+	// promptResolver resolves a prompt name to its text at execution time.
+	promptResolver PromptResolverFunc
 
 	// consecutiveFailures tracks how many times in a row a session's periodic
 	// prompt delivery failed due to ACP resume errors. After MaxPeriodicResumeFailures
@@ -115,6 +122,11 @@ func (r *PeriodicRunner) SetArchiveRetentionPeriod(period string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.archiveRetentionPeriod = period
+}
+
+// SetPromptResolver sets the function used to resolve prompt names to their text at execution time.
+func (r *PeriodicRunner) SetPromptResolver(resolver PromptResolverFunc) {
+	r.promptResolver = resolver
 }
 
 // Start begins the periodic polling loop in a background goroutine.
@@ -410,7 +422,7 @@ func (r *PeriodicRunner) checkSession(meta session.Metadata, now time.Time) (del
 						"consecutive_failures", failures)
 				}
 				disabled := false
-				if updateErr := periodicStore.Update(nil, nil, &disabled); updateErr != nil {
+				if updateErr := periodicStore.Update(nil, nil, nil, &disabled); updateErr != nil {
 					if r.logger != nil {
 						r.logger.Error("Failed to disable periodic schedule",
 							"session_id", sessionID,
@@ -466,12 +478,32 @@ func (r *PeriodicRunner) checkSession(meta session.Metadata, now time.Time) (del
 func (r *PeriodicRunner) deliverPrompt(bs *BackgroundSession, sessionName string, periodic *session.PeriodicPrompt, periodicStore *session.PeriodicStore, resetTimer bool, forced bool) error {
 	sessionID := bs.GetSessionID()
 
+	// Resolve prompt text from name if needed
+	promptText := periodic.Prompt
+	if periodic.PromptName != "" && r.promptResolver != nil {
+		sessionMeta, err := r.store.GetMetadata(sessionID)
+		if err != nil {
+			return fmt.Errorf("failed to get session metadata for prompt resolution: %w", err)
+		}
+		resolved, err := r.promptResolver(periodic.PromptName, sessionMeta.WorkingDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve prompt %q: %w", periodic.PromptName, err)
+		}
+		promptText = resolved
+		if r.logger != nil {
+			r.logger.Debug("Resolved periodic prompt name to text",
+				"session_id", sessionID,
+				"prompt_name", periodic.PromptName,
+				"prompt_preview", truncatePrompt(promptText, 100))
+		}
+	}
+
 	if r.logger != nil {
 		r.logger.Debug("Delivering periodic prompt",
 			"session_id", sessionID,
 			"session_name", sessionName,
 			"reset_timer", resetTimer,
-			"prompt_preview", truncatePrompt(periodic.Prompt, 100))
+			"prompt_preview", truncatePrompt(promptText, 100))
 	}
 
 	// Use OnComplete callback to defer RecordSent until the prompt actually finishes.
@@ -523,7 +555,7 @@ func (r *PeriodicRunner) deliverPrompt(bs *BackgroundSession, sessionName string
 		},
 	}
 
-	if err := bs.PromptWithMeta(periodic.Prompt, meta); err != nil {
+	if err := bs.PromptWithMeta(promptText, meta); err != nil {
 		return err
 	}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -583,6 +584,11 @@ func NewServer(config Config) (*Server, error) {
 			logger.Info("Periodic archive retention cleanup enabled", "retention_period", retentionPeriod)
 		}
 	}
+
+	// Set prompt resolver for periodic runner — resolves prompt names to text at execution time
+	s.periodicRunner.SetPromptResolver(func(promptName string, workingDir string) (string, error) {
+		return s.resolvePromptByName(promptName, workingDir)
+	})
 
 	s.periodicRunner.Start()
 
@@ -1450,6 +1456,95 @@ func (s *Server) getPromptsWatchDirs() []string {
 	}
 
 	return dirs
+}
+
+// resolvePromptByName resolves a prompt name to its full text for a given working directory.
+// Uses the same prompt resolution pipeline as the workspace prompts API endpoint.
+func (s *Server) resolvePromptByName(promptName string, workingDir string) (string, error) {
+	// 1. Global file prompts
+	var globalFilePrompts []configPkg.WebPrompt
+	if s.config.PromptsCache != nil {
+		gfp, err := s.config.PromptsCache.GetWebPrompts()
+		if err != nil && s.logger != nil {
+			s.logger.Warn("Failed to load global file prompts for prompt resolution", "error", err)
+		}
+		globalFilePrompts = gfp
+	}
+
+	// 2. Settings file prompts
+	var settingsPrompts []configPkg.WebPrompt
+	if s.config.MittoConfig != nil {
+		settingsPrompts = s.config.MittoConfig.Prompts
+	}
+
+	// 3. ACP server-specific prompts
+	var acpServerName, acpServerType string
+	if s.sessionManager != nil {
+		if ws := s.sessionManager.GetWorkspace(workingDir); ws != nil {
+			acpServerName = ws.ACPServer
+		}
+	}
+	if acpServerName != "" && s.config.MittoConfig != nil {
+		acpServerType = s.config.MittoConfig.GetServerType(acpServerName)
+	}
+	if acpServerType == "" {
+		acpServerType = acpServerName
+	}
+
+	var serverPrompts []configPkg.WebPrompt
+	if acpServerType != "" && s.config.PromptsCache != nil {
+		sp, err := s.config.PromptsCache.GetWebPromptsSpecificToACP(acpServerType)
+		if err != nil && s.logger != nil {
+			s.logger.Warn("Failed to load ACP-specific prompts for resolution", "error", err)
+		}
+		serverPrompts = sp
+	}
+	if acpServerName != "" && s.config.MittoConfig != nil {
+		for _, srv := range s.config.MittoConfig.ACPServers {
+			if srv.Name == acpServerName {
+				serverPrompts = append(serverPrompts, srv.Prompts...)
+				break
+			}
+		}
+	}
+
+	// 4. Workspace directory prompts
+	var workspacePromptsDirs []string
+	defaultDir := appdir.WorkspacePromptsDir(workingDir)
+	workspacePromptsDirs = append(workspacePromptsDirs, defaultDir)
+	if s.sessionManager != nil {
+		workspacePromptsDirs = append(workspacePromptsDirs, s.sessionManager.GetWorkspacePromptsDirs(workingDir)...)
+	}
+	dirPrompts := s.loadPromptsFromDirs(workingDir, workspacePromptsDirs)
+
+	// 5. Workspace inline prompts (.mittorc)
+	var inlinePrompts []configPkg.WebPrompt
+	if s.sessionManager != nil {
+		inlinePrompts = s.sessionManager.GetWorkspacePrompts(workingDir)
+	}
+
+	// Merge with proper priority (same as handleWorkspacePromptsGET)
+	merged := configPkg.MergePrompts(
+		configPkg.MergePrompts(
+			configPkg.MergePrompts(globalFilePrompts, settingsPrompts, serverPrompts),
+			nil,
+			dirPrompts,
+		),
+		nil,
+		inlinePrompts,
+	)
+
+	// Find the prompt by name (case-insensitive)
+	for _, p := range merged {
+		if strings.EqualFold(p.Name, promptName) {
+			if p.Prompt == "" {
+				return "", fmt.Errorf("prompt %q has no content", promptName)
+			}
+			return p.Prompt, nil
+		}
+	}
+
+	return "", fmt.Errorf("prompt %q not found", promptName)
 }
 
 // parseAutoArchivePeriod converts an auto-archive period string to a duration.

--- a/internal/web/session_api.go
+++ b/internal/web/session_api.go
@@ -1686,7 +1686,8 @@ type WebProcessor struct {
 	Description string                     `json:"description,omitempty"`
 	Enabled     bool                       `json:"enabled"`
 	Source      processors.ProcessorSource `json:"source"`
-	When        string                     `json:"when,omitempty"`
+	On          string                     `json:"on,omitempty"`
+	Match       string                     `json:"match,omitempty"`
 	Priority    int                        `json:"priority,omitempty"`
 	FilePath    string                     `json:"file_path,omitempty"`
 	Mode        string                     `json:"mode,omitempty"` // "text", "command", or "prompt"
@@ -1746,7 +1747,8 @@ func (s *Server) handleWorkspaceProcessors(w http.ResponseWriter, r *http.Reques
 			Description: p.Description,
 			Enabled:     enabled,
 			Source:      p.Source,
-			When:        string(p.When),
+			On:          string(p.When.On),
+			Match:       string(p.When.Match),
 			Priority:    p.Priority,
 			FilePath:    p.FilePath,
 			Mode:        mode,

--- a/internal/web/session_manager.go
+++ b/internal/web/session_manager.go
@@ -753,8 +753,13 @@ func (sm *SessionManager) GetWorkspaceAllProcessorDirs(workingDir string) []stri
 // processors loaded from .mitto/processors/ and any processors_dirs in .mittorc.
 // Returns the original manager if no workspace processors are found.
 func (sm *SessionManager) loadWorkspaceProcessors(procMgr *processors.Manager, workingDir string) *processors.Manager {
-	if procMgr == nil || workingDir == "" {
+	if workingDir == "" {
 		return procMgr
+	}
+	// If no global processor manager exists yet, create a minimal empty one so
+	// workspace-local processors can still be loaded and executed.
+	if procMgr == nil {
+		procMgr = processors.NewManager("", sm.logger)
 	}
 
 	var dirs []string

--- a/internal/web/session_periodic_api.go
+++ b/internal/web/session_periodic_api.go
@@ -9,16 +9,18 @@ import (
 
 // PeriodicPromptRequest is the request body for creating/updating a periodic prompt.
 type PeriodicPromptRequest struct {
-	Prompt    string            `json:"prompt"`
-	Frequency session.Frequency `json:"frequency"`
-	Enabled   bool              `json:"enabled"`
+	Prompt     string            `json:"prompt"`
+	PromptName string            `json:"prompt_name,omitempty"`
+	Frequency  session.Frequency `json:"frequency"`
+	Enabled    bool              `json:"enabled"`
 }
 
 // PeriodicPromptPatchRequest is the request body for partial updates.
 type PeriodicPromptPatchRequest struct {
-	Prompt    *string            `json:"prompt,omitempty"`
-	Frequency *session.Frequency `json:"frequency,omitempty"`
-	Enabled   *bool              `json:"enabled,omitempty"`
+	Prompt     *string            `json:"prompt,omitempty"`
+	PromptName *string            `json:"prompt_name,omitempty"`
+	Frequency  *session.Frequency `json:"frequency,omitempty"`
+	Enabled    *bool              `json:"enabled,omitempty"`
 }
 
 // handleSessionPeriodic handles periodic prompt operations for a session.
@@ -96,9 +98,10 @@ func (s *Server) handleSetPeriodic(w http.ResponseWriter, r *http.Request, sessi
 	}
 
 	p := &session.PeriodicPrompt{
-		Prompt:    req.Prompt,
-		Frequency: req.Frequency,
-		Enabled:   req.Enabled,
+		Prompt:     req.Prompt,
+		PromptName: req.PromptName,
+		Frequency:  req.Frequency,
+		Enabled:    req.Enabled,
 	}
 
 	if err := ps.Set(p); err != nil {
@@ -133,7 +136,7 @@ func (s *Server) handlePatchPeriodic(w http.ResponseWriter, r *http.Request, ses
 		return
 	}
 
-	if err := ps.Update(req.Prompt, req.Frequency, req.Enabled); err != nil {
+	if err := ps.Update(req.Prompt, req.PromptName, req.Frequency, req.Enabled); err != nil {
 		if err == session.ErrPeriodicNotFound {
 			http.Error(w, "No periodic prompt configured", http.StatusNotFound)
 			return

--- a/internal/web/session_ws.go
+++ b/internal/web/session_ws.go
@@ -30,6 +30,18 @@ func generateClientID() string {
 	return hex.EncodeToString(b)
 }
 
+// buildContextUsageMap creates a JSON-serialisable map for context window usage.
+// Returns nil when both size and used are zero (no data available).
+func buildContextUsageMap(size, used int) map[string]interface{} {
+	if size == 0 && used == 0 {
+		return nil
+	}
+	return map[string]interface{}{
+		"size": size,
+		"used": used,
+	}
+}
+
 // buildUsageMap converts an acp.Usage value into a JSON-serialisable map
 // suitable for embedding in WebSocket messages.  Returns nil when usage is nil.
 func buildUsageMap(usage *acp.Usage) map[string]interface{} {
@@ -462,6 +474,10 @@ func (c *SessionWSClient) sendSessionConnected(bs *BackgroundSession) {
 	if bs != nil {
 		if usageMap := buildUsageMap(bs.GetLastUsage()); usageMap != nil {
 			data["usage"] = usageMap
+		}
+		// Include context window usage if available.
+		if ctxUsageMap := buildContextUsageMap(bs.GetContextUsage()); ctxUsageMap != nil {
+			data["context_usage"] = ctxUsageMap
 		}
 	}
 
@@ -2118,8 +2134,21 @@ func (c *SessionWSClient) OnPromptComplete(eventCount int) {
 		if usageMap := buildUsageMap(c.bgSession.GetLastUsage()); usageMap != nil {
 			data["usage"] = usageMap
 		}
+		// Include context window usage if available.
+		if ctxUsageMap := buildContextUsageMap(c.bgSession.GetContextUsage()); ctxUsageMap != nil {
+			data["context_usage"] = ctxUsageMap
+		}
 	}
 	c.sendMessage(WSMsgTypePromptComplete, data)
+}
+
+// OnContextUsageUpdate is called when context window usage data is updated.
+func (c *SessionWSClient) OnContextUsageUpdate(size, used int) {
+	c.sendMessage(WSMsgTypeContextUsageUpdate, map[string]interface{}{
+		"session_id": c.sessionID,
+		"size":       size,
+		"used":       used,
+	})
 }
 
 // OnActionButtons is called when action buttons are extracted from the agent's response.

--- a/internal/web/ws_messages.go
+++ b/internal/web/ws_messages.go
@@ -404,6 +404,11 @@ const (
 	//   "patterns": map[string]bool  // e.g., {"jira_*": true, "slack_*": false}
 	// }
 	WSMsgTypeRequiredToolsStatus = "required_tools_status"
+
+	// WSMsgTypeContextUsageUpdate notifies the client of context window usage changes.
+	// Sent when the agent sends a SessionUsageUpdate notification.
+	// Data: { "session_id": string, "size": int, "used": int }
+	WSMsgTypeContextUsageUpdate = "context_usage_update"
 )
 
 // =============================================================================

--- a/internal/web/ws_messages_test.go
+++ b/internal/web/ws_messages_test.go
@@ -371,6 +371,7 @@ func (m *replayTestObserver) OnACPStarted()                                     
 func (m *replayTestObserver) OnUIPrompt(_ UIPromptRequest)                        {}
 func (m *replayTestObserver) OnUIPromptDismiss(_ string, _ string)                {}
 func (m *replayTestObserver) OnNotification(_ UINotifyRequest)                    {}
+func (m *replayTestObserver) OnContextUsageUpdate(_ int, _ int)                   {}
 
 func TestBufferedEvent_ReplayTo(t *testing.T) {
 	observer := &replayTestObserver{}
@@ -830,6 +831,7 @@ func (o *testReplayObserver) OnACPStarted()                                     
 func (o *testReplayObserver) OnUIPrompt(req UIPromptRequest)                         {}
 func (o *testReplayObserver) OnUIPromptDismiss(requestID string, reason string)      {}
 func (o *testReplayObserver) OnNotification(req UINotifyRequest)                     {}
+func (o *testReplayObserver) OnContextUsageUpdate(size, used int)                    {}
 func (o *testReplayObserver) OnPermission(ctx context.Context, params acp.RequestPermissionRequest) (acp.RequestPermissionResponse, error) {
 	return acp.RequestPermissionResponse{}, nil
 }

--- a/samples/processors/attach-image.yaml
+++ b/samples/processors/attach-image.yaml
@@ -20,8 +20,10 @@ name: attach-image
 description: "Attaches images when message contains @image:path"
 enabled: true
 
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 priority: 80  # Run early to process image attachments
 
 command: ./attach-image.sh

--- a/samples/processors/file-context.yaml
+++ b/samples/processors/file-context.yaml
@@ -19,8 +19,10 @@ name: file-context
 description: "Attaches file contents when message contains @file:path"
 enabled: true
 
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 priority: 90  # Run before git hooks
 
 command: ./file-context.sh

--- a/samples/processors/git-diff.yaml
+++ b/samples/processors/git-diff.yaml
@@ -16,8 +16,10 @@ name: git-diff
 description: "Attaches git diff when message contains @git:diff"
 enabled: true
 
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 priority: 100
 
 command: ./git-diff.sh

--- a/samples/processors/git-status.yaml
+++ b/samples/processors/git-status.yaml
@@ -19,8 +19,10 @@ description: "Attaches git status when message contains @git:status"
 enabled: true
 
 # Apply to all messages (we filter by @git-status in the script)
-when: all
-position: prepend
+when:
+  on: userPrompt
+  match: all
+mutate: prepend
 priority: 100
 
 # Use companion script in the same directory

--- a/samples/processors/timestamp.yaml
+++ b/samples/processors/timestamp.yaml
@@ -2,7 +2,7 @@
 # Adds current date/time to the first message of each conversation
 #
 # This is a simple example that demonstrates:
-# - Using "when: first" to only run on the first message
+# - Using "when.on: userPrompt, match: first" to only run on the first message
 # - Using "output: prepend" to add context before the message
 # - A minimal hook that doesn't need the input message
 #
@@ -15,8 +15,10 @@ name: timestamp
 description: "Adds current timestamp to first message"
 enabled: true
 
-when: first       # Only on first message of conversation
-position: prepend
+when:
+  on: userPrompt
+  match: first      # Only on first message of conversation
+mutate: prepend
 priority: 200     # Run after other hooks
 
 command: ./timestamp.sh

--- a/tests/integration/inprocess/prompt_test.go
+++ b/tests/integration/inprocess/prompt_test.go
@@ -4,6 +4,9 @@ package inprocess
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -153,4 +156,104 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen]
+}
+
+// TestAfterPhaseProcessor_SentinelFile verifies that an on: agentResponded processor
+// fires after a prompt completes and produces a side effect (sentinel file).
+//
+// Strategy:
+//  1. Write a processor YAML to the workspace's .mitto/processors/ directory before
+//     creating any session (processors are loaded lazily at session-creation time).
+//  2. Send a prompt and wait for prompt_complete.
+//  3. Assert the sentinel file exists.
+func TestAfterPhaseProcessor_SentinelFile(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	// Determine sentinel path inside the test's temp dir (auto-cleaned).
+	sentinelPath := filepath.Join(ts.TempDir, "after-phase-fired.txt")
+
+	// Write the processor YAML before creating a session.
+	// The processor runs sh -c '...' and writes to the sentinel path.
+	processorsDir := filepath.Join(ts.TempDir, "workspace", ".mitto", "processors")
+	if err := os.MkdirAll(processorsDir, 0755); err != nil {
+		t.Fatalf("Failed to create processors dir: %v", err)
+	}
+
+	processorYAML := fmt.Sprintf(`name: after-test-sentinel
+when:
+  on: agentResponded
+  match: all
+command: sh
+args: ["-c", "echo fired >> %s"]
+output: discard
+`, sentinelPath)
+
+	yamlPath := filepath.Join(processorsDir, "after-test-sentinel.yaml")
+	if err := os.WriteFile(yamlPath, []byte(processorYAML), 0644); err != nil {
+		t.Fatalf("Failed to write processor YAML: %v", err)
+	}
+	t.Logf("Processor YAML written to %s", yamlPath)
+	t.Logf("Sentinel path: %s", sentinelPath)
+
+	// Create a session (processor is loaded at this point).
+	sess, err := ts.Client.CreateSession(client.CreateSessionRequest{})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	defer ts.Client.DeleteSession(sess.SessionID)
+
+	var (
+		mu             sync.Mutex
+		promptComplete bool
+	)
+
+	callbacks := client.SessionCallbacks{
+		OnPromptComplete: func(eventCount int) {
+			mu.Lock()
+			defer mu.Unlock()
+			promptComplete = true
+			t.Logf("Prompt complete: %d events", eventCount)
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ws, err := ts.Client.Connect(ctx, sess.SessionID, callbacks)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	if err := ws.LoadEvents(50, 0, 0); err != nil {
+		t.Fatalf("LoadEvents failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if err := ws.SendPrompt("Hello, test the after-phase processor"); err != nil {
+		t.Fatalf("SendPrompt failed: %v", err)
+	}
+
+	// Wait for prompt_complete.
+	waitFor(t, 20*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return promptComplete
+	}, "prompt complete")
+
+	// Give the after-phase processor a moment to finish writing the file.
+	// The processor runs synchronously in the prompt goroutine, so by the time
+	// prompt_complete is broadcast the processor should already be done.
+	// A brief sleep guards against any timing edge cases.
+	time.Sleep(500 * time.Millisecond)
+
+	// Assert the sentinel file was created.
+	if _, err := os.Stat(sentinelPath); os.IsNotExist(err) {
+		t.Errorf("After-phase processor did not fire: sentinel file %s does not exist", sentinelPath)
+	} else if err != nil {
+		t.Errorf("Error checking sentinel file: %v", err)
+	} else {
+		content, _ := os.ReadFile(sentinelPath)
+		t.Logf("Sentinel file content: %q", string(content))
+	}
 }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -5992,6 +5992,8 @@ function App() {
             sendKeyMode=${sendKeyMode}
             configOptions=${configOptions}
             onSetConfigOption=${setConfigOption}
+            contextUsage=${sessionInfo?.context_usage ?? null}
+            tokenUsage=${sessionInfo?.usage ?? null}
           />
         </div>
       </div>

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -22,8 +22,9 @@ import {
 import { useResizeHandle } from "../hooks/useResizeHandle.js";
 import { SlashCommandPicker } from "./SlashCommandPicker.js";
 import { PeriodicFrequencyPanel } from "./PeriodicFrequencyPanel.js";
+import { PeriodicPromptSelector } from "./PeriodicPromptSelector.js";
 import { SavePromptDialog } from "./SavePromptDialog.js";
-import { LockIcon, UnlockIcon, GripIcon } from "./Icons.js";
+import { GripIcon } from "./Icons.js";
 
 /**
  * Calculate contrasting text color (black or white) for a given background color.
@@ -376,9 +377,10 @@ export function ChatInput({
   // When locked, the prompt is saved to the periodic config and textarea is read-only
   const [isPeriodicLocked, setIsPeriodicLocked] = useState(false);
   const [isPeriodicSaving, setIsPeriodicSaving] = useState(false);
+  const [periodicPromptName, setPeriodicPromptName] = useState("");
 
-  // Max height for textarea: collapsed when periodic is locked, full otherwise
-  const textareaMaxHeight = periodicEnabled && isPeriodicLocked ? 80 : 200;
+  // Max height for textarea
+  const textareaMaxHeight = 200;
 
   // Scroll selected prompt into view when keyboard selection changes
   useEffect(() => {
@@ -437,6 +439,7 @@ export function ChatInput({
     setIsPeriodicLocked(false);
     setIsPeriodicSaving(false);
     setPeriodicPrompt("");
+    setPeriodicPromptName("");
     setPeriodicFrequency({ value: 1, unit: "hours" });
     setPeriodicNextScheduledAt(null);
   }, [sessionId]);
@@ -454,21 +457,25 @@ export function ChatInput({
       setIsPromptCollapsed(true); // Collapse prompt area when textbox appears
     } else if (activeUIPrompt?.promptType === "form") {
       setIsPromptCollapsed(true); // Collapse prompt area when form appears
-    } else {
-      setIsPromptCollapsed(false); // Expand when textbox/form disappears
+    } else if (!periodicEnabled) {
+      setIsPromptCollapsed(false); // Expand when textbox/form disappears (but not for periodic)
     }
-  }, [activeUIPrompt?.requestId]);
+  }, [activeUIPrompt?.requestId, periodicEnabled]);
 
   // Fetch periodic config when periodic is enabled for this session
   useEffect(() => {
     if (!periodicEnabled || !sessionId) {
       setIsPeriodicLocked(false);
       setPeriodicPrompt("");
+      setPeriodicPromptName("");
       setPeriodicFrequency({ value: 1, unit: "hours" });
       setPeriodicNextScheduledAt(null);
       // Don't clear the draft when disabling periodic - preserve user's text
       return;
     }
+
+    // Default to collapsed prompt area for periodic conversations
+    setIsPromptCollapsed(true);
 
     const fetchPeriodicConfig = async () => {
       try {
@@ -487,24 +494,17 @@ export function ChatInput({
           } else {
             setPeriodicNextScheduledAt(null);
           }
-          // Set prompt and locked state based on the enabled field
-          // Treat "(pending)" placeholder as unlocked - user needs to set a real prompt
+          // Update prompt name from config
+          setPeriodicPromptName(config.prompt_name || "");
+          // Set lock state based on the enabled field
+          const isLocked = config.enabled === true;
+          setIsPeriodicLocked(isLocked);
+          // Set prompt state based on config
           const isPendingPlaceholder = config.prompt === "(pending)";
           if (config.prompt && !isPendingPlaceholder) {
             setPeriodicPrompt(config.prompt);
-            // Lock state is based on enabled field from backend
-            const isLocked = config.enabled === true;
-            setIsPeriodicLocked(isLocked);
-            // Only set the draft to the periodic prompt if it's LOCKED
-            // If unlocked, preserve the user's current draft
-            if (isLocked && onDraftChange) {
-              onDraftChange(sessionId, config.prompt);
-            }
           } else {
             setPeriodicPrompt("");
-            setIsPeriodicLocked(false);
-            // Don't clear the draft for pending placeholder
-            // The user may have been typing - preserve their text
           }
         }
       } catch (err) {
@@ -513,7 +513,7 @@ export function ChatInput({
     };
 
     fetchPeriodicConfig();
-  }, [periodicEnabled, sessionId, onDraftChange]);
+  }, [periodicEnabled, sessionId]);
 
   // Listen for periodic config updates from other clients via WebSocket
   useEffect(() => {
@@ -555,17 +555,15 @@ export function ChatInput({
         if (nextScheduledAt) {
           setPeriodicNextScheduledAt(nextScheduledAt);
         }
-        // Fetch the full config to get the prompt
+        // Fetch the full config to get the prompt name
         authFetch(apiUrl(`/api/sessions/${sessionId}/periodic`))
           .then((response) => response.json())
           .then((config) => {
+            setPeriodicPromptName(config.prompt_name || "");
             const isPendingPlaceholder = config.prompt === "(pending)";
             if (config.prompt && !isPendingPlaceholder) {
               setPeriodicPrompt(config.prompt);
               setIsPeriodicLocked(true);
-              if (onDraftChange) {
-                onDraftChange(sessionId, config.prompt);
-              }
             }
           })
           .catch((err) =>
@@ -584,7 +582,7 @@ export function ChatInput({
         handlePeriodicConfigUpdated,
       );
     };
-  }, [sessionId, onDraftChange]);
+  }, [sessionId]);
 
   // Compute slash command filter from current text (text after '/' when text starts with '/')
   const slashFilter =
@@ -861,6 +859,34 @@ export function ChatInput({
       }
     } catch (err) {
       console.error("Failed to unlock periodic prompt:", err);
+    } finally {
+      setIsPeriodicSaving(false);
+    }
+  }, [sessionId, isPeriodicSaving]);
+
+  // Handle periodic prompt selection from PeriodicPromptSelector
+  const handlePeriodicPromptSelect = useCallback(async (promptName) => {
+    if (!sessionId || isPeriodicSaving) return;
+    setIsPeriodicSaving(true);
+    try {
+      const response = await secureFetch(
+        apiUrl(`/api/sessions/${sessionId}/periodic`),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt_name: promptName, enabled: true }),
+        },
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setPeriodicPromptName(promptName);
+        setIsPeriodicLocked(true);
+        if (data.next_scheduled_at) {
+          setPeriodicNextScheduledAt(data.next_scheduled_at);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to save periodic prompt selection:", err);
     } finally {
       setIsPeriodicSaving(false);
     }
@@ -1698,6 +1724,19 @@ export function ChatInput({
         />
       </div>
 
+      <!-- Periodic Prompt Selector (Row 2, shown when periodic is enabled) -->
+      <div class="max-w-4xl mx-auto">
+        <${PeriodicPromptSelector}
+          isOpen=${periodicEnabled}
+          prompts=${predefinedPrompts}
+          selectedPromptName=${periodicPromptName}
+          disabled=${false}
+          onSelect=${handlePeriodicPromptSelect}
+          isPromptAreaVisible=${!isPromptCollapsed}
+          onTogglePromptArea=${() => setIsPromptCollapsed((v) => !v)}
+        />
+      </div>
+
       <!-- UI Prompt from MCP tool (unified menu or permission) -->
       ${hasActiveUIPrompt &&
       html`
@@ -2268,7 +2307,8 @@ ${activeUIPrompt.text || ""}</textarea
       `}
       ${!(
         isPromptCollapsed &&
-        (activeUIPrompt?.promptType === "textbox" ||
+        (periodicEnabled ||
+          activeUIPrompt?.promptType === "textbox" ||
           activeUIPrompt?.promptType === "form")
       ) &&
       html`
@@ -2515,24 +2555,16 @@ ${activeUIPrompt.text || ""}</textarea
                 onPaste=${handlePaste}
                 onFocus=${handleTextareaFocus}
                 onBlur=${handleTextareaBlur}
-                placeholder=${periodicEnabled
-                  ? isPeriodicLocked
-                    ? "Periodic prompt locked — click 🔓 to edit"
-                    : "Type your recurring prompt, then click 🔒 to activate"
-                  : getPlaceholder()}
+                placeholder=${getPlaceholder()}
                 rows="3"
-                class="chat-input-textarea ${periodicEnabled && isPeriodicLocked
-                  ? "max-h-[80px] overflow-y-auto"
-                  : "max-h-[200px] overflow-y-auto"} ${isFullyDisabled ||
+                class="chat-input-textarea max-h-[200px] overflow-y-auto ${isFullyDisabled ||
                 isReadOnly ||
-                isImproving ||
-                (periodicEnabled && isPeriodicLocked)
+                isImproving
                   ? "opacity-50 cursor-not-allowed"
                   : ""}"
                 disabled=${isFullyDisabled ||
                 isReadOnly ||
-                isImproving ||
-                (periodicEnabled && isPeriodicLocked)}
+                isImproving}
               />
 
               <!-- Improving prompt overlay with spinner -->
@@ -2807,7 +2839,7 @@ ${activeUIPrompt.text || ""}</textarea
                     type="button"
                     onClick=${handleTogglePrompts}
                     onMouseDown=${(e) => e.preventDefault()}
-                    disabled=${isFullyDisabled || isReadOnly || (periodicEnabled && isPeriodicLocked)}
+                    disabled=${isFullyDisabled || isReadOnly}
                     class="chat-input-action"
                     title="Insert predefined prompt"
                   >
@@ -2837,44 +2869,8 @@ ${activeUIPrompt.text || ""}</textarea
                 </button>
                 `}
 
-                <!-- Send/Stop/Lock button -->
-                ${periodicEnabled
-                  ? isPeriodicSaving
-                    ? html`
-                        <!-- Saving spinner -->
-                        <button type="button" disabled class="chat-input-action">
-                          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                          </svg>
-                        </button>
-                      `
-                    : isPeriodicLocked
-                      ? html`
-                          <!-- Locked state: click to unlock -->
-                          <button
-                            type="button"
-                            onClick=${handleUnlockPeriodicPrompt}
-                            class="chat-input-action"
-                            style="background: #2563eb !important; color: white !important;"
-                            title="Unlock to edit periodic prompt"
-                          >
-                            <${LockIcon} className="w-4 h-4" />
-                          </button>
-                        `
-                      : html`
-                          <!-- Unlocked state: click to lock -->
-                          <button
-                            type="button"
-                            onClick=${handleLockPeriodicPrompt}
-                            disabled=${!text.trim()}
-                            class="chat-input-action"
-                            title=${!text.trim() ? "Enter a prompt to lock" : "Lock periodic prompt"}
-                          >
-                            <${UnlockIcon} className="w-4 h-4" />
-                          </button>
-                        `
-                  : isStreaming
+                <!-- Send/Stop button -->
+                ${isStreaming
                     ? html`
                         <!-- Stop button -->
                         <button

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -13,6 +13,7 @@ import {
 } from "../utils/native.js";
 import { secureFetch, authFetch } from "../utils/csrf.js";
 import { apiUrl } from "../utils/api.js";
+import { getContextWindowSize } from "../utils/models.js";
 import {
   getPromptSortMode,
   getUIPromptPanelHeight,
@@ -190,6 +191,8 @@ export function ChatInput({
   sendKeyMode = "enter",
   configOptions = [],
   onSetConfigOption,
+  contextUsage = null,
+  tokenUsage = null,
 }) {
   // Use the draft from parent state instead of local state
   const text = draft;
@@ -217,6 +220,29 @@ export function ChatInput({
   const selectConfigOptions = useMemo(() => {
     return configOptions?.filter((o) => o.type === "select" && o.options?.length > 0) || [];
   }, [configOptions]);
+
+  // Compute context window usage percentage (null when no data available).
+  // Prefers context_usage from ACP SessionUsageUpdate (exact size/used).
+  // Falls back to input_tokens from PromptResponse.Usage + static model context window.
+  const contextPct = useMemo(() => {
+    // Primary: use SessionUsageUpdate data if available
+    if (contextUsage?.size && contextUsage?.used) {
+      return Math.min(Math.round((contextUsage.used / contextUsage.size) * 100), 100);
+    }
+    // Fallback: compute from input_tokens + known model context window
+    if (tokenUsage?.input_tokens) {
+      // Find current model ID from config options
+      const modelOpt = configOptions?.find((o) => o.category === "model");
+      const modelId = modelOpt?.current_value;
+      if (modelId) {
+        const ctxWindow = getContextWindowSize(modelId);
+        if (ctxWindow) {
+          return Math.min(Math.round((tokenUsage.input_tokens / ctxWindow) * 100), 100);
+        }
+      }
+    }
+    return null;
+  }, [contextUsage, tokenUsage, configOptions]);
 
   // Compute flat ordered prompt list for keyboard navigation
   const flatFilteredPrompts = useMemo(() => {
@@ -2631,8 +2657,31 @@ ${activeUIPrompt.text || ""}</textarea
 
             <!-- Bottom toolbar bar -->
             <div class="chat-input-bottom-bar">
-              <!-- Left action buttons: attach-image, attach-file, improve, save, clear -->
+              <!-- Left action buttons: improve, attach-image, attach-file, save, clear -->
               <div class="chat-input-actions-left">
+                <!-- Magic Wand / Improve Prompt Button -->
+                <button
+                  type="button"
+                  onClick=${handleImprovePrompt}
+                  onMouseDown=${(e) => e.preventDefault()}
+                  disabled=${isFullyDisabled || !text.trim() || isReadOnly || isImproving}
+                  class="chat-input-action ${isImproving ? "loading" : ""}"
+                  title="Improve prompt with AI (Ctrl+P)"
+                >
+                  ${isImproving
+                    ? html`
+                        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                      `
+                    : html`
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                        </svg>
+                      `}
+                </button>
+
                 <!-- Attach Image Button -->
                 <button
                   type="button"
@@ -2659,29 +2708,6 @@ ${activeUIPrompt.text || ""}</textarea
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
                   </svg>
-                </button>
-
-                <!-- Magic Wand / Improve Prompt Button -->
-                <button
-                  type="button"
-                  onClick=${handleImprovePrompt}
-                  onMouseDown=${(e) => e.preventDefault()}
-                  disabled=${isFullyDisabled || !text.trim() || isReadOnly || isImproving}
-                  class="chat-input-action ${isImproving ? "loading" : ""}"
-                  title="Improve prompt with AI (Ctrl+P)"
-                >
-                  ${isImproving
-                    ? html`
-                        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                      `
-                    : html`
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                        </svg>
-                      `}
                 </button>
 
                 <!-- Save Prompt Button (macOS native only) -->
@@ -2721,8 +2747,8 @@ ${activeUIPrompt.text || ""}</textarea
                 </button>
               </div>
 
-              <!-- Center: Config selectors (shown when select-type options are available) -->
-              ${selectConfigOptions.length > 0 && html`
+              <!-- Center: Config selectors and context usage (shown when either is available) -->
+              ${(selectConfigOptions.length > 0 || contextPct !== null) && html`
                 <div class="chat-input-model-selector">
                   ${selectConfigOptions.map((configOpt) => html`
                     <select
@@ -2738,6 +2764,15 @@ ${activeUIPrompt.text || ""}</textarea
                       `)}
                     </select>
                   `)}
+                  ${contextPct !== null && html`
+                    <span
+                      class="chat-input-context-pct"
+                      style=${"color: " + (contextPct > 80 ? "#ef4444" : contextPct > 50 ? "#f59e0b" : "#64748b")}
+                      title=${contextUsage?.size
+                        ? "Context: " + (contextUsage.used || 0).toLocaleString() + " / " + contextUsage.size.toLocaleString() + " tokens"
+                        : "Context: ~" + (tokenUsage?.input_tokens || 0).toLocaleString() + " input tokens"}
+                    >${contextPct}%</span>
+                  `}
                 </div>
               `}
 

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -226,7 +226,7 @@ export function ChatInput({
   // Falls back to input_tokens from PromptResponse.Usage + static model context window.
   const contextPct = useMemo(() => {
     // Primary: use SessionUsageUpdate data if available
-    if (contextUsage?.size && contextUsage?.used) {
+    if (contextUsage?.size > 0 && contextUsage?.used != null) {
       return Math.min(Math.round((contextUsage.used / contextUsage.size) * 100), 100);
     }
     // Fallback: compute from input_tokens + known model context window

--- a/web/static/components/ChatInput.js
+++ b/web/static/components/ChatInput.js
@@ -2290,8 +2290,8 @@ ${activeUIPrompt.text || ""}</textarea
             hasPrompts &&
             html`
               <div
-                class="absolute bottom-full right-0 mb-2 w-64 bg-slate-800 border border-slate-600 rounded-xl overflow-hidden z-50 max-h-80 flex flex-col"
-                style="box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 8px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1);"
+                class="absolute bottom-full right-0 mb-2 w-72 bg-slate-800 border border-slate-600 rounded-xl overflow-hidden z-50 flex flex-col"
+                style="max-height: 400px; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), 0 8px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1);"
               >
                 <!-- Filter input -->
                 <div class="px-2 pt-2 pb-1 flex-shrink-0">

--- a/web/static/components/ConversationPropertiesPanel.js
+++ b/web/static/components/ConversationPropertiesPanel.js
@@ -19,6 +19,7 @@ import { secureFetch, authFetch } from "../utils/csrf.js";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { formatTimeAgo } from "../lib.js";
 import { canRevealInFinder, revealInFinder } from "../utils/native.js";
+import { getContextWindowSize } from "../utils/models.js";
 
 /**
  * Format a token count into a compact human-readable string.
@@ -30,46 +31,6 @@ function formatTokenCount(count) {
   if (count >= 1000000) return `${(count / 1000000).toFixed(1)}M`;
   if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
   return count.toString();
-}
-
-/**
- * Known context window sizes (in tokens) for common models.
- * Keys are substrings matched case-insensitively against the model ID.
- */
-const MODEL_CONTEXT_WINDOWS = {
-  "gemini-2.5": 1048576,
-  "gemini-2.0": 1048576,
-  "gemini-1.5": 1048576,
-  "gemini": 1048576,
-  "o4-mini": 200000,
-  "opus": 200000,
-  "sonnet": 200000,
-  "haiku": 200000,
-  "claude": 200000,
-  "o1": 200000,
-  "o3": 200000,
-  "gpt-4o": 128000,
-  "gpt-4-turbo": 128000,
-  "gpt-4": 8192,
-  "gpt-3.5": 16385,
-};
-
-/**
- * Look up the context window size for a model ID.
- * Matches by checking if the model ID contains any known key (case-insensitive),
- * trying longer (more specific) keys first.
- * Returns null if no match found.
- * @param {string|null} modelId
- * @returns {number|null}
- */
-function getContextWindowSize(modelId) {
-  if (!modelId) return null;
-  const lower = modelId.toLowerCase();
-  const sortedKeys = Object.keys(MODEL_CONTEXT_WINDOWS).sort((a, b) => b.length - a.length);
-  for (const key of sortedKeys) {
-    if (lower.includes(key)) return MODEL_CONTEXT_WINDOWS[key];
-  }
-  return null;
 }
 
 /**

--- a/web/static/components/PeriodicPromptSelector.js
+++ b/web/static/components/PeriodicPromptSelector.js
@@ -1,0 +1,258 @@
+// Mitto Web Interface - Periodic Prompt Selector Component
+// Dropdown for selecting a workspace prompt as the periodic prompt
+
+const {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+  html,
+} = window.preact;
+
+/**
+ * PeriodicPromptSelector - dropdown for selecting a workspace prompt as the periodic prompt
+ * @param {Object} props
+ * @param {Array} props.prompts - Available workspace prompts (same as predefinedPrompts)
+ * @param {string} props.selectedPromptName - Currently selected prompt name (from periodic config)
+ * @param {boolean} props.disabled - Whether the selector is read-only
+ * @param {Function} props.onSelect - Callback when a prompt is selected: (promptName) => void
+ * @param {boolean} props.isOpen - Whether the panel is visible
+ * @param {boolean} props.isPromptAreaVisible - Whether the prompt composition area below is visible
+ * @param {Function} props.onTogglePromptArea - Callback to toggle prompt composition area visibility
+ */
+export function PeriodicPromptSelector({
+  prompts = [],
+  selectedPromptName = "",
+  disabled = false,
+  onSelect,
+  isOpen = false,
+  isPromptAreaVisible = false,
+  onTogglePromptArea,
+}) {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [filterText, setFilterText] = useState("");
+  const dropdownRef = useRef(null);
+  const filterInputRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!showDropdown) return;
+    const handleClickOutside = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setShowDropdown(false);
+        setFilterText("");
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showDropdown]);
+
+  // Focus filter input when dropdown opens
+  useEffect(() => {
+    if (showDropdown && filterInputRef.current) {
+      filterInputRef.current.focus();
+    }
+  }, [showDropdown]);
+
+  // Filter and group prompts
+  const { groupedPrompts, ungroupedPrompts, sortedGroupNames, hasResults } =
+    useMemo(() => {
+      const lowerFilter = filterText.toLowerCase().trim();
+      const filtered = lowerFilter
+        ? prompts.filter(
+            (p) =>
+              (p.name || "").toLowerCase().includes(lowerFilter) ||
+              (p.description || "").toLowerCase().includes(lowerFilter),
+          )
+        : prompts;
+
+      const grouped = {};
+      const ungrouped = [];
+      filtered.forEach((prompt) => {
+        if (prompt.group) {
+          if (!grouped[prompt.group]) grouped[prompt.group] = [];
+          grouped[prompt.group].push(prompt);
+        } else {
+          ungrouped.push(prompt);
+        }
+      });
+      // Sort within groups
+      Object.keys(grouped).forEach((g) => {
+        grouped[g].sort((a, b) => a.name.localeCompare(b.name));
+      });
+      const sortedUngrouped = [...ungrouped].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+
+      return {
+        groupedPrompts: grouped,
+        ungroupedPrompts: sortedUngrouped,
+        sortedGroupNames: Object.keys(grouped).sort(),
+        hasResults: filtered.length > 0,
+      };
+    }, [prompts, filterText]);
+
+  const handleToggle = useCallback(() => {
+    if (disabled) return;
+    setShowDropdown((prev) => !prev);
+    setFilterText("");
+  }, [disabled]);
+
+  const handleSelect = useCallback(
+    (prompt) => {
+      if (onSelect) {
+        onSelect(prompt.name);
+      }
+      setShowDropdown(false);
+      setFilterText("");
+    },
+    [onSelect],
+  );
+
+  // Panel classes - matches PeriodicFrequencyPanel style
+  const panelClasses = `periodic-prompt-selector w-full bg-slate-100 dark:bg-slate-700/95 backdrop-blur-sm border border-slate-300 dark:border-slate-600 rounded-lg overflow-visible transition-all duration-300 ease-out ${
+    isOpen
+      ? "opacity-100 mb-3"
+      : "opacity-0 pointer-events-none h-0 border-0 mb-0"
+  }`;
+
+  const panelStyle = isOpen ? "height: 44px; position: relative;" : "height: 0px;";
+
+  const displayName = selectedPromptName || "Select a prompt...";
+
+  // Render a single prompt item in the dropdown
+  const renderPromptItem = (prompt) => {
+    const isSelected = prompt.name === selectedPromptName;
+    return html`
+      <button
+        key=${"periodic-prompt-" + prompt.name}
+        type="button"
+        onClick=${() => handleSelect(prompt)}
+        title=${prompt.description || prompt.name}
+        class="w-full text-left px-4 py-2.5 text-sm transition-all flex items-center gap-2 ${isSelected
+          ? "bg-blue-600/20 text-white"
+          : "text-gray-200 hover:bg-slate-600/50"}"
+      >
+        <svg class="w-4 h-4 flex-shrink-0 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
+        <span class="truncate flex-1">${prompt.name}</span>
+        ${isSelected && html`
+          <svg class="w-4 h-4 flex-shrink-0 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+          </svg>
+        `}
+      </button>
+    `;
+  };
+
+
+  return html`
+    <div
+      class="${panelClasses}"
+      style="${panelStyle}"
+      data-testid="periodic-prompt-selector"
+      ref=${dropdownRef}
+    >
+      <div class="h-full px-4 flex items-center gap-3 text-sm">
+        <!-- Label -->
+        <span class="text-slate-600 dark:text-gray-300 flex-shrink-0 font-medium">Prompt:</span>
+
+        <!-- Dropdown trigger button -->
+        <button
+          type="button"
+          onClick=${handleToggle}
+          disabled=${disabled}
+          class="flex-1 h-8 px-3 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded text-sm text-left flex items-center gap-2 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors ${
+            disabled
+              ? "opacity-50 cursor-not-allowed"
+              : "cursor-pointer hover:border-blue-500/50"
+          }"
+          data-testid="periodic-prompt-selector-button"
+        >
+          <span class="truncate flex-1 ${selectedPromptName ? "text-slate-900 dark:text-white" : "text-slate-400 dark:text-gray-500"}">${displayName}</span>
+          <svg class="w-4 h-4 flex-shrink-0 text-slate-400 transition-transform ${showDropdown ? "rotate-180" : ""}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <!-- Toggle prompt composition area button -->
+        ${onTogglePromptArea && html`
+          <button
+            type="button"
+            onClick=${onTogglePromptArea}
+            class="flex-shrink-0 p-1.5 text-gray-400 hover:text-white transition-colors rounded hover:bg-slate-600"
+            title=${isPromptAreaVisible
+              ? "Hide message input"
+              : "Show message input"}
+            data-testid="periodic-toggle-prompt-area"
+          >
+            <svg
+              class="w-4 h-4 transition-transform ${isPromptAreaVisible ? "rotate-180" : ""}"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        `}
+      </div>
+
+      <!-- Dropdown panel (appears ABOVE the selector) -->
+      ${showDropdown && html`
+        <div
+          class="absolute bottom-full left-0 right-0 mb-1 bg-slate-800 border border-slate-600 rounded-lg shadow-xl z-50 overflow-hidden"
+          style="max-height: 360px; display: flex; flex-direction: column;"
+          data-testid="periodic-prompt-selector-dropdown"
+        >
+          <!-- Search filter -->
+          <div class="p-2 border-b border-slate-700">
+            <input
+              ref=${filterInputRef}
+              type="text"
+              value=${filterText}
+              onInput=${(e) => setFilterText(e.target.value)}
+              placeholder="Search prompts..."
+              class="w-full h-8 px-3 bg-slate-900 border border-slate-600 rounded text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              data-testid="periodic-prompt-selector-search"
+            />
+          </div>
+
+          <!-- Prompt list -->
+          <div class="overflow-y-auto flex-1" style="max-height: 310px;">
+            ${sortedGroupNames.map(
+              (groupName) => html`
+                <div key=${"pps-group-" + groupName}>
+                  <div class="px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider bg-slate-700/30">
+                    ${groupName}
+                  </div>
+                  ${groupedPrompts[groupName].map((prompt) => renderPromptItem(prompt))}
+                </div>
+              `,
+            )}
+            ${ungroupedPrompts.length > 0 ? html`
+              <div key="pps-group-other">
+                <div class="px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider bg-slate-700/30">
+                  Other
+                </div>
+                ${ungroupedPrompts.map((prompt) => renderPromptItem(prompt))}
+              </div>
+            ` : ""}
+            ${!hasResults ? html`
+              <div class="px-4 py-3 text-xs text-gray-500 text-center">
+                No matching prompts
+              </div>
+            ` : ""}
+          </div>
+        </div>
+      `}
+    </div>
+  `;
+}

--- a/web/static/components/WorkspacesDialog.js
+++ b/web/static/components/WorkspacesDialog.js
@@ -1418,7 +1418,7 @@ export function WorkspacesDialog({ isOpen, onClose, onSave, WorkspaceBadge }) {
                                                 <span class="text-sm font-medium font-mono ${isEnabled ? 'text-blue-400' : 'text-gray-500'}">${proc.name}</span>
                                                 <span class="text-xs px-1.5 py-0.5 rounded ${sourceBadgeClass}">${sourceLabel}</span>
                                                 ${isPromptMode && html`<span class="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">prompt</span>`}
-                                                ${proc.when && html`<span class="text-xs text-gray-500">when: ${proc.when}</span>`}
+                                                ${proc.on && html`<span class="text-xs text-gray-500">${proc.on}${proc.match ? `:${proc.match}` : ''}</span>`}
                                               </div>
                                               ${proc.description && html`<p class="text-xs text-gray-500 mt-0.5 truncate">${proc.description}</p>`}
                                             </div>

--- a/web/static/hooks/useWebSocket.js
+++ b/web/static/hooks/useWebSocket.js
@@ -1193,6 +1193,8 @@ export function useWebSocket() {
                 processor_last_names: msg.data.processor_last_names ?? session.info?.processor_last_names ?? null,
                 // Token usage from last prompt
                 usage: msg.data.usage ?? session.info?.usage ?? null,
+                // Context window usage (size/used from ACP)
+                context_usage: msg.data.context_usage ?? session.info?.context_usage ?? null,
                 // Config options (model, mode, etc.) - per-session
                 // Use ?? to preserve existing options when server omits the field (e.g. pre-acp_started reconnect)
                 config_options: msg.data.config_options ?? session.info?.config_options ?? [],
@@ -1669,6 +1671,8 @@ export function useWebSocket() {
                 processor_last_names: msg.data.processor_last_names ?? session.info?.processor_last_names ?? null,
                 // Token usage from last prompt
                 usage: msg.data.usage ?? session.info?.usage ?? null,
+                // Context window usage (updated with each prompt)
+                context_usage: msg.data.context_usage ?? session.info?.context_usage ?? null,
               },
             },
           };
@@ -2829,6 +2833,28 @@ export function useWebSocket() {
           setAvailableCommands(msg.data.commands);
         }
         break;
+
+      case "context_usage_update": {
+        // Context window usage updated by the agent
+        setSessions((prev) => {
+          const session = prev[sessionId];
+          if (!session) return prev;
+          return {
+            ...prev,
+            [sessionId]: {
+              ...session,
+              info: {
+                ...session.info,
+                context_usage: {
+                  size: msg.data.size,
+                  used: msg.data.used,
+                },
+              },
+            },
+          };
+        });
+        break;
+      }
 
       case "config_option_changed":
         // Config option changed (by user or agent)

--- a/web/static/styles-v2.css
+++ b/web/static/styles-v2.css
@@ -1610,6 +1610,12 @@ a:hover {
   }
 }
 
+.v2-theme .chat-input-context-pct {
+  font-size: 11px;
+  white-space: nowrap;
+  padding: 1px 4px;
+}
+
 /* Send/Stop buttons — filled accent in both v2 themes */
 .v2-theme:not(.dark) .chat-input-action.send-active,
 .v2-theme:not(.dark) .chat-input-action.stop-active {

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1511,6 +1511,12 @@ mitto-action {
   color: #94a3b8;
 }
 
+.chat-input-context-pct {
+  font-size: 11px;
+  white-space: nowrap;
+  padding: 1px 4px;
+}
+
 .chat-input-model-select:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/web/static/utils/models.js
+++ b/web/static/utils/models.js
@@ -1,0 +1,42 @@
+// Model context window utilities
+// Shared between ChatInput and ConversationPropertiesPanel
+
+/**
+ * Known context window sizes (in tokens) for common models.
+ * Keys are substrings matched case-insensitively against the model ID.
+ */
+const MODEL_CONTEXT_WINDOWS = {
+  "gemini-2.5": 1048576,
+  "gemini-2.0": 1048576,
+  "gemini-1.5": 1048576,
+  "gemini": 1048576,
+  "o4-mini": 200000,
+  "opus": 200000,
+  "sonnet": 200000,
+  "haiku": 200000,
+  "claude": 200000,
+  "o1": 200000,
+  "o3": 200000,
+  "gpt-4o": 128000,
+  "gpt-4-turbo": 128000,
+  "gpt-4": 8192,
+  "gpt-3.5": 16385,
+};
+
+/**
+ * Look up the context window size for a model ID.
+ * Matches by checking if the model ID contains any known key (case-insensitive),
+ * trying longer (more specific) keys first.
+ * Returns null if no match found.
+ * @param {string|null} modelId
+ * @returns {number|null}
+ */
+export function getContextWindowSize(modelId) {
+  if (!modelId) return null;
+  const lower = modelId.toLowerCase();
+  const sortedKeys = Object.keys(MODEL_CONTEXT_WINDOWS).sort((a, b) => b.length - a.length);
+  for (const key of sortedKeys) {
+    if (lower.includes(key)) return MODEL_CONTEXT_WINDOWS[key];
+  }
+  return null;
+}


### PR DESCRIPTION
Major rewrite of the message-processor system.

## Schema overhaul
- `when:` is now a required block: `{ on, match, ... }` — legacy scalar form (`when: first`) is rejected at load time.
- `on:` selects the lifecycle phase: `userPrompt` (pre-send, existing behaviour) or `agentResponded` (new post-response phase).
- `match:` takes `first`, `all`, or `allExceptFirst` (camelCase only; former `all-except-first` is rejected).
- `position:` renamed to `mutate:` for userPrompt processors.

## After-phase (`on: agentResponded`)
- New executor runs command- and prompt-mode processors after the agent finishes responding, with the turn context (text, tools used, token usage, stop reason) passed via stdin (command mode) or `@mitto:` template variables (prompt mode).
- Output handlers: `discard`, `notify`, `actionButtons`, `userData`.
- Optional filters: `stopReasons` (snake_case, e.g. `end_turn`) and `excludeOrigins`.

## Cadence throttling (`when.cadence`)
- `everyNTurns`, `everyNTokens`, and `afterInterval` (Go duration) gate firing of after-phase processors. All specified thresholds must be met (AND).
- Only valid with `on: agentResponded`; rejected with `match: first`.

## Persisted state
- New `<session_dir>/processor_state.json` stores `AgentResponseCount` and per-processor cadence counters via `fileutil.WriteJSONAtomic`.
- `StateStore` interface with `FileStateStore` (prod) and `MemoryStateStore` (tests). Clock injection via `Manager.SetClock`.
- `match: first` now survives session restarts.

## Built-in migrations
- `identify-user-data` and `memorize-preferences` moved from `userPrompt/first/rerun` to `agentResponded/all/cadence` (`everyNTurns: 3/5`, `everyNTokens: 15k/30k`, +5m interval on memorize-preferences). Both extractors now see agent messages in their history retrieval.
- All other built-ins and samples migrated to the new block form without behaviour change.

## Tests
- 4 new `processors_test` cases (cadence everyNTurns/afterInterval, state persistence, validation)
- New integration test (`TestAfterPhaseProcessor_SentinelFile`) proving end-to-end after-phase firing

## Other changes in this branch
- `style(ui):` widen prompts dropdown and lift max height
