### PR TITLE
feat(mcp): add since/until time-range filtering to conversation_history

### DIFF
--- a/docs/devel/mcp.md
+++ b/docs/devel/mcp.md
@@ -588,6 +588,8 @@ Get and search through the conversation history of a session. Returns events wit
 | `text_excludes`   | string   | No       | Exclude events whose text content contains this substring (case-insensitive) |
 | `after_seq`       | int      | No       | Only events with seq > this value                                   |
 | `before_seq`      | int      | No       | Only events with seq < this value                                   |
+| `since`           | string   | No       | Only events at/after this time. RFC 3339 timestamp (e.g. `2024-01-15T10:30:00Z`) or relative duration ago (e.g. `3m`, `1h`, `2h30m`) |
+| `until`           | string   | No       | Only events at/before this time. Same format as `since`             |
 | `last_n`          | int      | No       | Return last N matching events (default: 50, max: 200)               |
 | `offset`          | int      | No       | Skip this many matching events from the end (for backward pagination) |
 | `include_data`    | bool     | No       | Include full event data in results (default: true)                  |
@@ -624,6 +626,8 @@ Each event contains:
 - Find all errors in a session: `event_types: ["error"]`
 - Get the last 10 user prompts: `event_types: ["user_prompt"], last_n: 10`
 - Browse history page by page: `last_n: 20, offset: 0` then `last_n: 20, offset: 20`
+- Get everything from the last 30 minutes: `since: "30m"`
+- Get events in a time window: `since: "1h", until: "10m"` (between 1 hour and 10 minutes ago)
 
 #### `mitto_prompt_list`
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1275,6 +1275,8 @@ func (s *Server) registerSessionScopedTools(mcpSrv *mcp.Server) {
 			"Returns events (user prompts, agent messages, tool calls, etc.) with powerful filtering. " +
 			"Useful for recalling past decisions, finding specific tool calls, searching for errors, " +
 			"or reviewing what happened in a conversation. " +
+			"Filter by time range with 'since' and 'until': both accept an absolute RFC 3339 timestamp " +
+			"(e.g., '2024-01-15T10:30:00Z') or a relative duration meaning ago (e.g., '3m', '1h', '2h30m'). " +
 			"Defaults to your own conversation if conversation_id is omitted. " +
 			selfIDNote,
 	}, s.handleConversationHistory)
@@ -4744,8 +4746,27 @@ func (s *Server) handleConversationHistory(ctx context.Context, req *mcp.CallToo
 
 	totalEvents := len(allEvents)
 
+	// Parse optional time-range filters (RFC 3339 absolute, or relative duration "ago").
+	var since, until time.Time
+	if input.Since != "" {
+		t, err := session.ParseHistoryTime(input.Since)
+		if err != nil {
+			emptyOut.Error = fmt.Sprintf("invalid since: %v", err)
+			return nil, emptyOut, nil
+		}
+		since = t
+	}
+	if input.Until != "" {
+		t, err := session.ParseHistoryTime(input.Until)
+		if err != nil {
+			emptyOut.Error = fmt.Sprintf("invalid until: %v", err)
+			return nil, emptyOut, nil
+		}
+		until = t
+	}
+
 	// Apply filters.
-	filtered := historyFilterEvents(allEvents, input)
+	filtered := historyFilterEvents(allEvents, input, since, until)
 
 	// Apply pagination: last_n and offset.
 	// "last_n" means we return the most recent N events.
@@ -4798,7 +4819,9 @@ func (s *Server) handleConversationHistory(ctx context.Context, req *mcp.CallToo
 }
 
 // historyFilterEvents applies all configured filters to the event list.
-func historyFilterEvents(events []session.Event, input ConversationHistoryInput) []session.Event {
+// since and until are optional time-range bounds (zero value means unset):
+// events before `since` or after `until` are excluded.
+func historyFilterEvents(events []session.Event, input ConversationHistoryInput, since, until time.Time) []session.Event {
 	// Build event type set for O(1) lookup.
 	var typeSet map[string]bool
 	if len(input.EventTypes) > 0 {
@@ -4819,6 +4842,14 @@ func historyFilterEvents(events []session.Event, input ConversationHistoryInput)
 			continue
 		}
 		if input.BeforeSeq > 0 && e.Seq >= input.BeforeSeq {
+			continue
+		}
+
+		// Time range filters.
+		if !since.IsZero() && e.Timestamp.Before(since) {
+			continue
+		}
+		if !until.IsZero() && e.Timestamp.After(until) {
 			continue
 		}
 

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -7451,6 +7451,137 @@ func TestConversationHistory_SeqRange(t *testing.T) {
 	}
 }
 
+func TestConversationHistory_TimeRange(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := session.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	sessionID := session.GenerateSessionID()
+	if err := store.Create(session.Metadata{
+		SessionID:  sessionID,
+		Name:       "TimeRange Test",
+		ACPServer:  "test-server",
+		WorkingDir: "/test/dir",
+	}); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	// Append events with explicit, distinct timestamps. AppendEvent preserves a
+	// non-zero Timestamp, so we can place events at known points in the past.
+	now := time.Now()
+	times := []time.Time{
+		now.Add(-30 * time.Minute),
+		now.Add(-20 * time.Minute),
+		now.Add(-10 * time.Minute),
+		now.Add(-1 * time.Minute),
+	}
+	for i, ts := range times {
+		ev := session.Event{
+			Type:      session.EventTypeUserPrompt,
+			Timestamp: ts,
+			Data:      session.UserPromptData{Message: fmt.Sprintf("msg %d", i)},
+		}
+		if err := store.AppendEvent(sessionID, ev); err != nil {
+			t.Fatalf("AppendEvent failed: %v", err)
+		}
+	}
+
+	srv, err := NewServer(Config{Port: 0}, Dependencies{Store: store})
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := srv.RegisterSession(sessionID, nil, logger); err != nil {
+		t.Fatalf("Failed to register session: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// since="15m" (15 minutes ago) → events at -10m and -1m.
+	_, out, err := srv.handleConversationHistory(ctx, nil, ConversationHistoryInput{
+		SelfID: sessionID,
+		Since:  "15m",
+		LastN:  200,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("expected success: %s", out.Error)
+	}
+	if out.ReturnedEvents != 2 {
+		t.Errorf("since=15m: ReturnedEvents = %d, want 2", out.ReturnedEvents)
+	}
+
+	// until="15m" (15 minutes ago) → events at -30m and -20m.
+	_, out, err = srv.handleConversationHistory(ctx, nil, ConversationHistoryInput{
+		SelfID: sessionID,
+		Until:  "15m",
+		LastN:  200,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("expected success: %s", out.Error)
+	}
+	if out.ReturnedEvents != 2 {
+		t.Errorf("until=15m: ReturnedEvents = %d, want 2", out.ReturnedEvents)
+	}
+
+	// Combined since="25m" and until="5m" → events at -20m and -10m.
+	_, out, err = srv.handleConversationHistory(ctx, nil, ConversationHistoryInput{
+		SelfID: sessionID,
+		Since:  "25m",
+		Until:  "5m",
+		LastN:  200,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("expected success: %s", out.Error)
+	}
+	if out.ReturnedEvents != 2 {
+		t.Errorf("since=25m,until=5m: ReturnedEvents = %d, want 2", out.ReturnedEvents)
+	}
+
+	// Absolute RFC 3339 since (15 minutes ago) → events at -10m and -1m.
+	absSince := now.Add(-15 * time.Minute).Format(time.RFC3339)
+	_, out, err = srv.handleConversationHistory(ctx, nil, ConversationHistoryInput{
+		SelfID: sessionID,
+		Since:  absSince,
+		LastN:  200,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("expected success: %s", out.Error)
+	}
+	if out.ReturnedEvents != 2 {
+		t.Errorf("since=%s: ReturnedEvents = %d, want 2", absSince, out.ReturnedEvents)
+	}
+
+	// Invalid since → error returned via output, not a Go error.
+	_, out, err = srv.handleConversationHistory(ctx, nil, ConversationHistoryInput{
+		SelfID: sessionID,
+		Since:  "not-a-time",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Success {
+		t.Error("expected failure for invalid since")
+	}
+	if out.Error == "" {
+		t.Error("expected non-empty Error for invalid since")
+	}
+}
+
 func TestConversationHistory_LastNPagination(t *testing.T) {
 	srv, sessionID := setupHistoryServer(t)
 	ctx := context.Background()

--- a/internal/mcpserver/types.go
+++ b/internal/mcpserver/types.go
@@ -766,6 +766,8 @@ type ConversationHistoryInput struct {
 	TextExcludes   string   `json:"text_excludes,omitempty"`   // Exclude events with text matching this (case-insensitive)
 	AfterSeq       int64    `json:"after_seq,omitempty"`       // Only events with seq > this
 	BeforeSeq      int64    `json:"before_seq,omitempty"`      // Only events with seq < this
+	Since          string   `json:"since,omitempty"`           // Only events at/after this time (RFC 3339 timestamp or relative duration "ago", e.g. "3m", "1h")
+	Until          string   `json:"until,omitempty"`           // Only events at/before this time (RFC 3339 timestamp or relative duration "ago", e.g. "3m", "1h")
 	LastN          int      `json:"last_n,omitempty"`          // Return last N matching events (default: 50, max: 200)
 	Offset         int      `json:"offset,omitempty"`          // Skip this many from the end (for pagination backward)
 	IncludeData    *bool    `json:"include_data,omitempty"`    // Include full event data (default: true)

--- a/internal/session/queue.go
+++ b/internal/session/queue.go
@@ -49,6 +49,30 @@ func ParseScheduleTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("invalid schedule_time %q: must be an RFC 3339 timestamp (e.g., 2024-01-15T10:30:00Z) or a relative duration (e.g., 5m, 1h, 2h30m)", s)
 }
 
+// ParseHistoryTime parses a time-filter string used for querying past history.
+// It accepts the same two formats as ParseScheduleTime, but a relative duration
+// is interpreted as "ago" (i.e., now minus the duration) rather than a future time:
+//   - An absolute RFC 3339 / ISO 8601 timestamp (e.g., "2024-01-15T10:30:00Z")
+//   - A relative duration using Go duration syntax meaning "ago" (e.g., "3m", "1h", "2h30m")
+//
+// Returns the resolved absolute time, or an error if the string is not a valid format.
+func ParseHistoryTime(s string) (time.Time, error) {
+	// Try RFC 3339 first
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	// Try Go duration format, interpreted as "ago" (e.g., "3m", "1h", "2h30m")
+	if d, err := time.ParseDuration(s); err == nil {
+		if d < 0 {
+			return time.Time{}, fmt.Errorf("duration must be positive, got %s", s)
+		}
+		return time.Now().Add(-d), nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid time %q: must be an RFC 3339 timestamp (e.g., 2024-01-15T10:30:00Z) or a relative duration ago (e.g., 3m, 1h, 2h30m)", s)
+}
+
 // QueuedMessage represents a message waiting to be sent to the agent.
 type QueuedMessage struct {
 	// ID is the unique identifier for this queued message (auto-assigned).


### PR DESCRIPTION
## Summary

Adds optional **time-range filtering** to the `mitto_conversation_history` MCP tool via two new parameters, `since` and `until`, complementing the existing seq-range filters (`after_seq` / `before_seq`).

Both parameters accept the same two formats already used by `schedule_time` and `initial_prompt_delay`:

- an absolute **RFC 3339** timestamp (e.g. `2024-01-15T10:30:00Z`)
- a relative duration interpreted as **"ago"** (e.g. `3m`, `1h`, `2h30m`)

## Changes

- **`internal/session/queue.go`** — new `ParseHistoryTime` helper. Mirrors `ParseScheduleTime`, but resolves relative durations into the **past** (`now - d`) rather than the future, and rejects negative durations.
- **`internal/mcpserver/types.go`** — added `Since` / `Until` fields to `ConversationHistoryInput`.
- **`internal/mcpserver/server.go`** — parse `since`/`until` up front in `handleConversationHistory` (errors returned via the output's `error` field); extended `historyFilterEvents` to skip events outside the `[since, until]` window; updated the tool description.
- **`internal/mcpserver/server_test.go`** — `TestConversationHistory_TimeRange` covering `since`, `until`, a combined window, absolute RFC 3339 input, and invalid input.
- **`docs/devel/mcp.md`** — documented the new parameters and added example use cases.

## Examples

- Last 30 minutes: `since: "30m"`
- Time window: `since: "1h", until: "10m"` (between 1 hour and 10 minutes ago)
- Absolute: `since: "2024-01-15T10:30:00Z"`

## Testing

- `go build ./...` passes
- `gofmt -l` — no diffs; `go vet` — clean
- `internal/session` and all `TestConversationHistory_*` tests pass (incl. the new time-range test)

## Notes

This is a server-side schema change; it takes effect once the Mitto binary is rebuilt and restarted.
