### PR TITLE
feat(loop): persist loop settings on un-loop; symmetric re-loop restore (mitto-0do)

### DIFF
--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -4084,6 +4084,13 @@ func (s *Server) handleConversationUpdate(ctx context.Context, req *mcp.CallTool
 					Error:   fmt.Sprintf("failed to set loop: %v", err),
 				}, nil
 			}
+			// A freshly-defined loop supersedes any previously-detached settings, so
+			// drop the saved slot — parity with the REST make-loop path so the
+			// un-loop⇄re-loop toggle stays symmetric regardless of which interface
+			// (re)created the loop.
+			if err := loopStore.ClearSaved(); err != nil {
+				s.logger.Warn("Failed to clear stale saved loop settings on MCP set", "error", err)
+			}
 		} else {
 			// Updating existing loop config — use partial update
 			var prompt *string

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -9755,6 +9755,63 @@ func TestConversationUpdate_SelfAlias(t *testing.T) {
 	}
 }
 
+// TestConversationUpdate_CreateLoopClearsSavedSlot verifies that creating a fresh
+// loop via MCP drops any previously-detached (un-looped) settings, so the
+// un-loop⇄re-loop toggle stays symmetric regardless of which interface recreated
+// the loop. A stale saved slot would otherwise be resurrected by a later restore.
+func TestConversationUpdate_CreateLoopClearsSavedSlot(t *testing.T) {
+	store, srv, parentID := setupConversationStartServer(t)
+	ctx := context.Background()
+
+	// Simulate a prior un-loop: seed a loop then Detach it to the saved slot.
+	loopStore := store.Loop(parentID)
+	if err := loopStore.Set(&session.LoopPrompt{
+		Prompt:    "old detached loop",
+		Frequency: session.Frequency{Value: 5, Unit: session.FrequencyHours},
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Set (seed) error = %v", err)
+	}
+	if err := loopStore.Detach(); err != nil {
+		t.Fatalf("Detach error = %v", err)
+	}
+	if _, err := loopStore.GetSaved(); err != nil {
+		t.Fatalf("GetSaved after Detach = %v, want nil (settings preserved)", err)
+	}
+
+	// Create a fresh loop via MCP (isNew path).
+	prompt := "brand new loop"
+	freqValue := 2
+	freqUnit := "hours"
+	_, out, err := srv.handleConversationUpdate(ctx, nil, ConversationUpdateInput{
+		SelfID:             parentID,
+		ConversationID:     parentID,
+		LoopPrompt:         &prompt,
+		LoopFrequencyValue: &freqValue,
+		LoopFrequencyUnit:  &freqUnit,
+	})
+	if err != nil {
+		t.Fatalf("handleConversationUpdate error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("update not successful: %s", out.Error)
+	}
+
+	// The active config is the fresh one.
+	active, err := loopStore.Get()
+	if err != nil {
+		t.Fatalf("Get after create = %v", err)
+	}
+	if active.Prompt != "brand new loop" {
+		t.Errorf("active.Prompt = %q, want %q", active.Prompt, "brand new loop")
+	}
+
+	// The stale saved slot must be cleared so a later restore cannot resurrect it.
+	if _, err := loopStore.GetSaved(); err != session.ErrLoopNotFound {
+		t.Errorf("GetSaved after MCP create = %v, want ErrLoopNotFound (stale slot cleared)", err)
+	}
+}
+
 // TestStartProgressHeartbeat verifies that startProgressHeartbeat returns a stop
 // function that terminates the background goroutine promptly without panicking.
 // The goroutine must exit via hbCtx.Done() before the 15-second ticker fires,

--- a/internal/session/loop.go
+++ b/internal/session/loop.go
@@ -16,6 +16,11 @@ import (
 
 const (
 	loopFileName = "loop.json"
+	// savedLoopFileName holds a detached loop configuration preserved when a
+	// conversation is reverted to a regular one via the "un-loop" button. It lets
+	// the settings (prompt, frequency, trigger, enabled state, …) be restored when
+	// the conversation is looped again, mirroring the archive/unarchive flow.
+	savedLoopFileName = "loop.saved.json"
 )
 
 // StoppedReason is the reason a loop conversation was automatically stopped.
@@ -479,6 +484,63 @@ func (ps *LoopStore) Delete() error {
 			return ErrLoopNotFound
 		}
 		return fmt.Errorf("failed to delete loop file: %w", err)
+	}
+	return nil
+}
+
+// savedLoopPath returns the path to the detached loop.saved.json file.
+func (ps *LoopStore) savedLoopPath() string {
+	return filepath.Join(ps.sessionDir, savedLoopFileName)
+}
+
+// Detach preserves the current loop configuration and removes the active one.
+// It copies loop.json to loop.saved.json and then deletes loop.json, so the
+// conversation reverts to a regular one (loop_configured=false) while its
+// settings survive for a later Restore. Any previously-saved config is
+// overwritten. Returns ErrLoopNotFound if no loop config exists.
+func (ps *LoopStore) Detach() error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	existing, err := ps.getUnlocked()
+	if err != nil {
+		return err
+	}
+
+	if err := fileutil.WriteJSONAtomic(ps.savedLoopPath(), existing, 0644); err != nil {
+		return fmt.Errorf("failed to write saved loop file: %w", err)
+	}
+	if err := os.Remove(ps.loopPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete loop file: %w", err)
+	}
+	return nil
+}
+
+// GetSaved retrieves the detached loop configuration preserved by Detach.
+// Returns ErrLoopNotFound if no saved config exists.
+func (ps *LoopStore) GetSaved() (*LoopPrompt, error) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	var p LoopPrompt
+	err := fileutil.ReadJSON(ps.savedLoopPath(), &p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrLoopNotFound
+		}
+		return nil, fmt.Errorf("failed to read saved loop file: %w", err)
+	}
+	return &p, nil
+}
+
+// ClearSaved removes the detached loop configuration. It is a no-op (returns nil)
+// when no saved config exists.
+func (ps *LoopStore) ClearSaved() error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if err := os.Remove(ps.savedLoopPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete saved loop file: %w", err)
 	}
 	return nil
 }

--- a/internal/session/loop_test.go
+++ b/internal/session/loop_test.go
@@ -1550,3 +1550,123 @@ func TestLoopStore_DeferNextSchedule_NotFound(t *testing.T) {
 		t.Errorf("DeferNextSchedule() on empty store error = %v, want ErrLoopNotFound", err)
 	}
 }
+
+// TestLoopStore_Detach_PreservesConfig verifies Detach moves the active loop
+// config to the saved slot: Get returns ErrLoopNotFound (conversation reverts to
+// regular) while GetSaved returns the preserved settings.
+func TestLoopStore_Detach_PreservesConfig(t *testing.T) {
+	dir := t.TempDir()
+	ps := NewLoopStore(dir)
+
+	orig := &LoopPrompt{
+		Prompt:    "keep going",
+		Frequency: Frequency{Value: 2, Unit: FrequencyHours},
+		Trigger:   TriggerOnCompletion,
+		Enabled:   true,
+	}
+	if err := ps.Set(orig); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if err := ps.Detach(); err != nil {
+		t.Fatalf("Detach() error = %v", err)
+	}
+
+	// Active config is gone.
+	if _, err := ps.Get(); err != ErrLoopNotFound {
+		t.Errorf("Get() after Detach error = %v, want ErrLoopNotFound", err)
+	}
+
+	// Saved config preserved.
+	saved, err := ps.GetSaved()
+	if err != nil {
+		t.Fatalf("GetSaved() error = %v", err)
+	}
+	if saved.Prompt != "keep going" {
+		t.Errorf("saved.Prompt = %q, want %q", saved.Prompt, "keep going")
+	}
+	if !saved.Enabled {
+		t.Errorf("saved.Enabled = false, want true (enabled state preserved)")
+	}
+	if saved.Trigger != TriggerOnCompletion {
+		t.Errorf("saved.Trigger = %q, want %q", saved.Trigger, TriggerOnCompletion)
+	}
+}
+
+// TestLoopStore_Detach_NotFound verifies Detach returns ErrLoopNotFound when
+// there is no active loop config.
+func TestLoopStore_Detach_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	ps := NewLoopStore(dir)
+
+	if err := ps.Detach(); err != ErrLoopNotFound {
+		t.Errorf("Detach() on empty store error = %v, want ErrLoopNotFound", err)
+	}
+}
+
+// TestLoopStore_GetSaved_NotFound verifies GetSaved returns ErrLoopNotFound when
+// nothing has been detached.
+func TestLoopStore_GetSaved_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	ps := NewLoopStore(dir)
+
+	if _, err := ps.GetSaved(); err != ErrLoopNotFound {
+		t.Errorf("GetSaved() on empty store error = %v, want ErrLoopNotFound", err)
+	}
+}
+
+// TestLoopStore_ClearSaved removes the saved slot and is a no-op when absent.
+func TestLoopStore_ClearSaved(t *testing.T) {
+	dir := t.TempDir()
+	ps := NewLoopStore(dir)
+
+	// No-op when nothing saved.
+	if err := ps.ClearSaved(); err != nil {
+		t.Errorf("ClearSaved() with no saved config error = %v, want nil", err)
+	}
+
+	if err := ps.Set(&LoopPrompt{
+		Prompt:    "x",
+		Frequency: Frequency{Value: 1, Unit: FrequencyHours},
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := ps.Detach(); err != nil {
+		t.Fatalf("Detach() error = %v", err)
+	}
+	if err := ps.ClearSaved(); err != nil {
+		t.Fatalf("ClearSaved() error = %v", err)
+	}
+	if _, err := ps.GetSaved(); err != ErrLoopNotFound {
+		t.Errorf("GetSaved() after ClearSaved error = %v, want ErrLoopNotFound", err)
+	}
+}
+
+// TestLoopStore_Detach_OverwritesPreviousSaved verifies a second Detach replaces
+// an earlier saved config rather than appending.
+func TestLoopStore_Detach_OverwritesPreviousSaved(t *testing.T) {
+	dir := t.TempDir()
+	ps := NewLoopStore(dir)
+
+	if err := ps.Set(&LoopPrompt{Prompt: "first", Frequency: Frequency{Value: 1, Unit: FrequencyHours}, Enabled: true}); err != nil {
+		t.Fatalf("Set() first error = %v", err)
+	}
+	if err := ps.Detach(); err != nil {
+		t.Fatalf("Detach() first error = %v", err)
+	}
+	if err := ps.Set(&LoopPrompt{Prompt: "second", Frequency: Frequency{Value: 1, Unit: FrequencyHours}, Enabled: false}); err != nil {
+		t.Fatalf("Set() second error = %v", err)
+	}
+	if err := ps.Detach(); err != nil {
+		t.Fatalf("Detach() second error = %v", err)
+	}
+
+	saved, err := ps.GetSaved()
+	if err != nil {
+		t.Fatalf("GetSaved() error = %v", err)
+	}
+	if saved.Prompt != "second" {
+		t.Errorf("saved.Prompt = %q, want %q (latest Detach wins)", saved.Prompt, "second")
+	}
+}

--- a/internal/web/handlers/session_loop.go
+++ b/internal/web/handlers/session_loop.go
@@ -82,6 +82,7 @@ func (h *Handlers) loopDelayFloor() int {
 // HandleSessionLoop handles loop prompt operations for a session.
 // Routes: GET, PUT, PATCH, DELETE /api/sessions/{id}/loop
 // Route: POST /api/sessions/{id}/loop/run-now (immediate delivery)
+// Route: POST /api/sessions/{id}/loop/restore (restore detached settings)
 func (h *Handlers) HandleSessionLoop(w http.ResponseWriter, r *http.Request, sessionID, subPath string) {
 	store := h.deps.Store
 	if store == nil {
@@ -113,6 +114,12 @@ func (h *Handlers) HandleSessionLoop(w http.ResponseWriter, r *http.Request, ses
 	}
 
 	loopStore := store.Loop(sessionID)
+
+	// Handle restore sub-path (re-loop from previously-saved settings).
+	if subPath == "restore" {
+		h.handleRestoreLoop(w, r, sessionID, loopStore)
+		return
+	}
 
 	switch r.Method {
 	case http.MethodGet:

--- a/internal/web/handlers/session_loop_run.go
+++ b/internal/web/handlers/session_loop_run.go
@@ -41,10 +41,31 @@ func (h *Handlers) handleDeleteLoop(w http.ResponseWriter, sessionID string, ps 
 // enabled state it had at un-loop time so loop ⇄ un-loop is a symmetric toggle.
 // Iteration/duration counters and the stopped reason are reset so the restored
 // loop starts its budget fresh. Returns 404 when there is nothing saved to
-// restore, letting the frontend fall back to creating a blank draft.
+// restore, letting the frontend fall back to creating a blank draft. Returns
+// 409 when an active loop already exists (both loop.json and loop.saved.json
+// are present) to prevent Set()'s update path from silently preserving stale
+// counters/CreatedAt from the active config and clobbering it.
 func (h *Handlers) handleRestoreLoop(w http.ResponseWriter, r *http.Request, sessionID string, ps *session.LoopStore) {
 	if r.Method != http.MethodPost {
 		methodNotAllowed(w)
+		return
+	}
+
+	// Guard: refuse to restore when an active loop already exists. Otherwise a
+	// stale loop.saved.json (e.g. a previous ClearSaved failure) combined with
+	// LoopStore.Set()'s update path — which preserves CreatedAt/IterationCount/
+	// FirstRunAt/LastSentAt from the existing active config — would silently
+	// clobber the live loop and undo the counter reset performed here. Callers
+	// must explicitly resolve the conflict (e.g. via DELETE /loop) before
+	// restoring the previously-saved settings.
+	if _, err := ps.Get(); err == nil {
+		writeErrorJSON(w, http.StatusConflict, "", "A loop is already configured; cannot restore saved settings")
+		return
+	} else if err != session.ErrLoopNotFound {
+		if h.deps.Logger != nil {
+			h.deps.Logger.Error("Failed to read active loop settings before restore", "error", err)
+		}
+		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to read active loop settings")
 		return
 	}
 

--- a/internal/web/handlers/session_loop_run.go
+++ b/internal/web/handlers/session_loop_run.go
@@ -9,23 +9,95 @@ import (
 )
 
 // handleDeleteLoop handles DELETE /api/sessions/{id}/loop
+//
+// This is the "un-loop" action. Instead of hard-deleting the config, it detaches
+// it: the settings are preserved in loop.saved.json so a later "Make loop" can
+// restore them (mirroring the archive/unarchive loop-persistence flow). The
+// active loop.json is removed, so the conversation reverts to a regular one
+// (loop_configured=false), exactly as before.
 func (h *Handlers) handleDeleteLoop(w http.ResponseWriter, sessionID string, ps *session.LoopStore) {
-	if err := ps.Delete(); err != nil {
+	if err := ps.Detach(); err != nil {
 		if err == session.ErrLoopNotFound {
 			writeErrorJSON(w, http.StatusNotFound, "", "No loop prompt configured")
 			return
 		}
 		if h.deps.Logger != nil {
-			h.deps.Logger.Error("Failed to delete loop prompt", "error", err)
+			h.deps.Logger.Error("Failed to detach loop prompt", "error", err)
 		}
-		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to delete loop prompt")
+		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to remove loop prompt")
 		return
 	}
 
-	// Broadcast loop disabled to all clients (nil means deleted)
+	// Broadcast loop disabled to all clients (nil means removed)
 	h.broadcastLoop(sessionID, nil)
 
 	writeNoContent(w)
+}
+
+// handleRestoreLoop handles POST /api/sessions/{id}/loop/restore
+//
+// This is the re-loop counterpart of handleDeleteLoop: it restores a loop
+// configuration previously preserved by Detach (loop.saved.json), preserving the
+// enabled state it had at un-loop time so loop ⇄ un-loop is a symmetric toggle.
+// Iteration/duration counters and the stopped reason are reset so the restored
+// loop starts its budget fresh. Returns 404 when there is nothing saved to
+// restore, letting the frontend fall back to creating a blank draft.
+func (h *Handlers) handleRestoreLoop(w http.ResponseWriter, r *http.Request, sessionID string, ps *session.LoopStore) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+
+	saved, err := ps.GetSaved()
+	if err != nil {
+		if err == session.ErrLoopNotFound {
+			writeErrorJSON(w, http.StatusNotFound, "", "No saved loop settings to restore")
+			return
+		}
+		if h.deps.Logger != nil {
+			h.deps.Logger.Error("Failed to read saved loop settings", "error", err)
+		}
+		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to read saved loop settings")
+		return
+	}
+
+	// Reset the run counters/anchors and stopped reason so the restored loop
+	// starts fresh; keep the saved enabled state so an actively-looping
+	// conversation resumes and a paused draft comes back paused.
+	saved.IterationCount = 0
+	saved.FirstRunAt = nil
+	saved.LastSentAt = nil
+	saved.StoppedReason = ""
+	saved.StoppedAt = nil
+	saved.NextScheduledAt = nil
+
+	if err := ps.Set(saved); err != nil {
+		if h.deps.Logger != nil {
+			h.deps.Logger.Error("Failed to restore loop settings", "error", err)
+		}
+		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to restore loop settings")
+		return
+	}
+	if err := ps.ClearSaved(); err != nil && h.deps.Logger != nil {
+		h.deps.Logger.Warn("Failed to clear saved loop settings after restore", "error", err)
+	}
+	h.resetLoopContinuation(sessionID)
+
+	updated, err := ps.Get()
+	if err != nil {
+		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to get restored loop prompt")
+		return
+	}
+
+	// Broadcast the restored loop state (includes full config).
+	h.broadcastLoop(sessionID, updated)
+
+	// Kick off the first run for a restored, enabled onCompletion conversation.
+	if h.deps.BootstrapOnCompletion != nil {
+		h.deps.BootstrapOnCompletion(sessionID)
+	}
+
+	writeJSONOK(w, updated)
 }
 
 // handleRunLoopNow handles POST /api/sessions/{id}/loop/run-now

--- a/internal/web/handlers/session_loop_test.go
+++ b/internal/web/handlers/session_loop_test.go
@@ -628,6 +628,115 @@ func TestHandleSessionLoop_SetClearsSavedSlot(t *testing.T) {
 	}
 }
 
+// TestHandleSessionLoop_RestoreRejectedWhenLoopActive verifies that POST
+// /loop/restore returns 409 Conflict when an active loop.json already exists
+// alongside a saved loop.saved.json (e.g. a previous ClearSaved silently
+// failed), and that the active loop's accumulated counters/anchors are NOT
+// modified by the rejected restore. This guards against LoopStore.Set()'s
+// update path silently preserving stale IterationCount/CreatedAt/FirstRunAt
+// from the active config and clobbering it with saved settings.
+func TestHandleSessionLoop_RestoreRejectedWhenLoopActive(t *testing.T) {
+	store, h := newLoopStore(t)
+	tmpDir := t.TempDir()
+
+	const sid = "test-restore-rejected-active"
+	if err := store.Create(session.Metadata{
+		SessionID:  sid,
+		ACPServer:  "test-server",
+		WorkingDir: tmpDir,
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Step 1: seed and detach an initial loop so loop.saved.json exists.
+	if err := store.Loop(sid).Set(&session.LoopPrompt{
+		Prompt:    "old saved settings",
+		Frequency: session.Frequency{Value: 5, Unit: session.FrequencyHours},
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Set (saved seed) error = %v", err)
+	}
+	if err := store.Loop(sid).Detach(); err != nil {
+		t.Fatalf("Detach error = %v", err)
+	}
+	if _, err := store.Loop(sid).GetSaved(); err != nil {
+		t.Fatalf("GetSaved after Detach = %v, want nil", err)
+	}
+
+	// Step 2: install a fresh active loop directly via the store (bypassing
+	// the handler on purpose so the saved slot is NOT cleared — this simulates
+	// the "ClearSaved previously failed" state the reviewer is concerned about).
+	if err := store.Loop(sid).Set(&session.LoopPrompt{
+		Prompt:    "brand new active loop",
+		Frequency: session.Frequency{Value: 2, Unit: session.FrequencyHours},
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Set (active) error = %v", err)
+	}
+	// Bump the counters on the active loop so we can prove they survive the
+	// rejected restore untouched.
+	if err := store.Loop(sid).RecordSent(); err != nil {
+		t.Fatalf("RecordSent error = %v", err)
+	}
+	if err := store.Loop(sid).RecordSent(); err != nil {
+		t.Fatalf("RecordSent error = %v", err)
+	}
+
+	before, err := store.Loop(sid).Get()
+	if err != nil {
+		t.Fatalf("Get (before restore) error = %v", err)
+	}
+	if before.IterationCount != 2 {
+		t.Fatalf("before.IterationCount = %d, want 2 (setup precondition)", before.IterationCount)
+	}
+	if before.FirstRunAt == nil || before.LastSentAt == nil {
+		t.Fatalf("before anchors nil, want set (setup precondition)")
+	}
+
+	// Precondition: both files must exist for this test to be meaningful.
+	if _, err := store.Loop(sid).GetSaved(); err != nil {
+		t.Fatalf("GetSaved (before restore) = %v, want nil (both files present)", err)
+	}
+
+	// Step 3: POST /loop/restore — must be rejected with 409 Conflict.
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sid+"/loop/restore", nil)
+	w := httptest.NewRecorder()
+	h.HandleSessionLoop(w, req, sid, "restore")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("POST restore with active loop: Status = %d, want %d. Body: %s",
+			w.Code, http.StatusConflict, w.Body.String())
+	}
+
+	// Step 4: the active loop must be UNCHANGED — prompt, counters, and
+	// anchors preserved (no silent clobber by Set()'s update path).
+	after, err := store.Loop(sid).Get()
+	if err != nil {
+		t.Fatalf("Get (after restore) error = %v", err)
+	}
+	if after.Prompt != "brand new active loop" {
+		t.Errorf("after.Prompt = %q, want %q (active loop clobbered by saved settings)",
+			after.Prompt, "brand new active loop")
+	}
+	if after.IterationCount != before.IterationCount {
+		t.Errorf("after.IterationCount = %d, want %d (counter reset by rejected restore)",
+			after.IterationCount, before.IterationCount)
+	}
+	if after.FirstRunAt == nil || !after.FirstRunAt.Equal(*before.FirstRunAt) {
+		t.Errorf("after.FirstRunAt = %v, want %v (anchor changed by rejected restore)",
+			after.FirstRunAt, before.FirstRunAt)
+	}
+	if after.LastSentAt == nil || !after.LastSentAt.Equal(*before.LastSentAt) {
+		t.Errorf("after.LastSentAt = %v, want %v (anchor changed by rejected restore)",
+			after.LastSentAt, before.LastSentAt)
+	}
+
+	// The saved slot must still be there — a rejected restore does not clear it,
+	// so the operator can resolve the conflict (DELETE + restore) without loss.
+	if _, err := store.Loop(sid).GetSaved(); err != nil {
+		t.Errorf("GetSaved (after rejected restore) = %v, want nil (saved slot cleared by rejected restore)", err)
+	}
+}
+
 // TestHandleSetLoop_PendingPlaceholderDoesNotBecomeTitle verifies that when a loop
 // prompt is set with a "(pending)" placeholder body plus a prompt_name, the generated title
 // is derived from the resolved prompt body rather than the placeholder.

--- a/internal/web/handlers/session_loop_test.go
+++ b/internal/web/handlers/session_loop_test.go
@@ -489,6 +489,145 @@ func TestHandleSessionLoop_DeleteRemovesConfig(t *testing.T) {
 	}
 }
 
+// TestHandleSessionLoop_UnloopRestoreRoundTrip verifies the un-loop → re-loop
+// symmetric toggle: DELETE detaches the config (preserving settings), a
+// subsequent POST /loop/restore brings it back with the same prompt and enabled
+// state, and the saved slot is cleared afterwards.
+func TestHandleSessionLoop_UnloopRestoreRoundTrip(t *testing.T) {
+	store, h := newLoopStore(t)
+	tmpDir := t.TempDir()
+
+	const sid = "test-unloop-restore"
+	if err := store.Create(session.Metadata{
+		SessionID:  sid,
+		ACPServer:  "test-server",
+		WorkingDir: tmpDir,
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Step 1: configure an active loop.
+	putLoopForTest(t, h, sid, LoopPromptRequest{
+		Prompt:    "keep going",
+		Frequency: session.Frequency{Value: 3, Unit: session.FrequencyHours},
+		Enabled:   true,
+	})
+
+	// Step 2: un-loop (DELETE) — detaches, config gone but saved.
+	delReq := httptest.NewRequest(http.MethodDelete, "/api/sessions/"+sid+"/loop", nil)
+	delW := httptest.NewRecorder()
+	h.HandleSessionLoop(delW, delReq, sid, "")
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("DELETE loop: Status = %d, want %d. Body: %s", delW.Code, http.StatusNoContent, delW.Body.String())
+	}
+	if _, err := store.Loop(sid).Get(); err != session.ErrLoopNotFound {
+		t.Fatalf("Get after un-loop = %v, want ErrLoopNotFound", err)
+	}
+	if _, err := store.Loop(sid).GetSaved(); err != nil {
+		t.Fatalf("GetSaved after un-loop = %v, want nil (settings preserved)", err)
+	}
+
+	// Step 3: re-loop (POST /loop/restore) — restores config + enabled state.
+	restReq := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sid+"/loop/restore", nil)
+	restW := httptest.NewRecorder()
+	h.HandleSessionLoop(restW, restReq, sid, "restore")
+	if restW.Code != http.StatusOK {
+		t.Fatalf("POST restore: Status = %d, want %d. Body: %s", restW.Code, http.StatusOK, restW.Body.String())
+	}
+	var restored session.LoopPrompt
+	if err := json.Unmarshal(restW.Body.Bytes(), &restored); err != nil {
+		t.Fatalf("decode restore response: %v", err)
+	}
+	if restored.Prompt != "keep going" {
+		t.Errorf("restored.Prompt = %q, want %q", restored.Prompt, "keep going")
+	}
+	if !restored.Enabled {
+		t.Errorf("restored.Enabled = false, want true (enabled state preserved)")
+	}
+	if restored.IterationCount != 0 {
+		t.Errorf("restored.IterationCount = %d, want 0 (counters reset)", restored.IterationCount)
+	}
+	if restored.StoppedReason != "" {
+		t.Errorf("restored.StoppedReason = %q, want empty", restored.StoppedReason)
+	}
+
+	// Active config is back.
+	if _, err := store.Loop(sid).Get(); err != nil {
+		t.Errorf("Get after restore = %v, want nil", err)
+	}
+	// Saved slot cleared after a successful restore.
+	if _, err := store.Loop(sid).GetSaved(); err != session.ErrLoopNotFound {
+		t.Errorf("GetSaved after restore = %v, want ErrLoopNotFound (cleared)", err)
+	}
+}
+
+// TestHandleSessionLoop_Restore_NotFound verifies POST /loop/restore returns 404
+// when there are no saved settings, so the frontend can fall back to a draft.
+func TestHandleSessionLoop_Restore_NotFound(t *testing.T) {
+	store, h := newLoopStore(t)
+	tmpDir := t.TempDir()
+
+	const sid = "test-restore-notfound"
+	if err := store.Create(session.Metadata{
+		SessionID:  sid,
+		ACPServer:  "test-server",
+		WorkingDir: tmpDir,
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sid+"/loop/restore", nil)
+	w := httptest.NewRecorder()
+	h.HandleSessionLoop(w, req, sid, "restore")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("POST restore with nothing saved: Status = %d, want %d. Body: %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
+// TestHandleSessionLoop_SetClearsSavedSlot verifies that a fresh make-loop (PUT)
+// drops any previously-detached settings: the saved slot is cleared so a later
+// restore cannot resurrect stale settings over the freshly-defined loop.
+func TestHandleSessionLoop_SetClearsSavedSlot(t *testing.T) {
+	store, h := newLoopStore(t)
+	tmpDir := t.TempDir()
+
+	const sid = "test-set-clears-saved"
+	if err := store.Create(session.Metadata{
+		SessionID:  sid,
+		ACPServer:  "test-server",
+		WorkingDir: tmpDir,
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Simulate a prior un-loop: seed a loop then Detach it to the saved slot.
+	if err := store.Loop(sid).Set(&session.LoopPrompt{
+		Prompt:    "old detached loop",
+		Frequency: session.Frequency{Value: 5, Unit: session.FrequencyHours},
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Set (seed) error = %v", err)
+	}
+	if err := store.Loop(sid).Detach(); err != nil {
+		t.Fatalf("Detach error = %v", err)
+	}
+	if _, err := store.Loop(sid).GetSaved(); err != nil {
+		t.Fatalf("GetSaved after Detach = %v, want nil (settings preserved)", err)
+	}
+
+	// Make a fresh loop via PUT.
+	putLoopForTest(t, h, sid, LoopPromptRequest{
+		Prompt:    "brand new loop",
+		Frequency: session.Frequency{Value: 2, Unit: session.FrequencyHours},
+		Enabled:   true,
+	})
+
+	// The stale saved slot must be cleared so a later restore cannot resurrect it.
+	if _, err := store.Loop(sid).GetSaved(); err != session.ErrLoopNotFound {
+		t.Errorf("GetSaved after PUT = %v, want ErrLoopNotFound (stale slot cleared)", err)
+	}
+}
+
 // TestHandleSetLoop_PendingPlaceholderDoesNotBecomeTitle verifies that when a loop
 // prompt is set with a "(pending)" placeholder body plus a prompt_name, the generated title
 // is derived from the resolved prompt body rather than the placeholder.

--- a/internal/web/handlers/session_loop_write.go
+++ b/internal/web/handlers/session_loop_write.go
@@ -60,6 +60,12 @@ func (h *Handlers) handleSetLoop(w http.ResponseWriter, r *http.Request, session
 		writeErrorJSON(w, http.StatusInternalServerError, "", "Failed to set loop prompt")
 		return
 	}
+	// A freshly-defined loop supersedes any previously-detached settings, so drop
+	// the saved slot. This keeps the un-loop⇄re-loop toggle symmetric: the saved
+	// slot only ever holds the last active config (see Detach), never a stale one.
+	if err := ps.ClearSaved(); err != nil && h.deps.Logger != nil {
+		h.deps.Logger.Warn("Failed to clear stale saved loop settings on set", "error", err)
+	}
 	h.resetLoopContinuation(sessionID)
 
 	// Return the updated loop prompt

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1918,16 +1918,38 @@ function App() {
     // (cross-window), mirroring how deletion defers to removeSession (mitto-17d).
   };
 
-  // Convert an existing regular conversation to a loop one by creating a
-  // draft loop config (enabled:false). The loop_updated WebSocket event
-  // sets loop_configured=true (reveals the inline loop editor in ChatInput)
-  // while loop_enabled stays false (conversation remains in the Conversations
-  // group). The user must explicitly enable scheduling to move it to Loop group.
+  // Convert an existing regular conversation to a loop one. First try to restore
+  // settings that were preserved by a previous "un-loop" (POST /loop/restore);
+  // this brings back the saved prompt/frequency/trigger and its enabled state,
+  // making loop ⇄ un-loop a symmetric toggle. When there is nothing saved (404),
+  // fall back to creating a blank draft config (enabled:false). Either way the
+  // loop_updated WebSocket event sets loop_configured=true (reveals the inline
+  // loop editor in ChatInput).
   const handleMakeLoop = useCallback(
     async (session) => {
       const sessionId = session?.session_id;
       if (!sessionId) return;
       try {
+        // Attempt to restore previously-saved loop settings.
+        const restoreRes = await secureFetch(
+          endpoints.sessions.loopRestore(sessionId),
+          { method: "POST" },
+        );
+        if (restoreRes.ok) {
+          focusSession(sessionId);
+          showToast({
+            style: "success",
+            title: "Loop settings restored",
+            message: "Your previous loop settings were restored.",
+            duration: 6000,
+          });
+          return;
+        }
+        if (restoreRes.status !== 404) {
+          throw new Error(`HTTP ${restoreRes.status}`);
+        }
+
+        // Nothing saved — create a fresh draft config.
         const res = await secureFetch(endpoints.sessions.loop(sessionId), {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -1974,7 +1996,8 @@ function App() {
         showToast({
           style: "success",
           title: "Loop scheduling removed",
-          message: "The conversation is now a regular conversation.",
+          message:
+            "Now a regular conversation. Your loop settings are saved and will be restored if you loop it again.",
           duration: 6000,
         });
       } catch (e) {

--- a/web/static/utils/endpoints.js
+++ b/web/static/utils/endpoints.js
@@ -64,6 +64,7 @@ export const endpoints = {
     settings: (id) => apiUrl(`/api/sessions/${enc(id)}/settings`),
     loop: (id) => apiUrl(`/api/sessions/${enc(id)}/loop`),
     loopRunNow: (id) => apiUrl(`/api/sessions/${enc(id)}/loop/run-now`),
+    loopRestore: (id) => apiUrl(`/api/sessions/${enc(id)}/loop/restore`),
     flush: (id) => apiUrl(`/api/sessions/${enc(id)}/flush`),
     callback: (id) => apiUrl(`/api/sessions/${enc(id)}/callback`),
     userData: (id) => apiUrl(`/api/sessions/${enc(id)}/user-data`),


### PR DESCRIPTION
## Summary

Extends the archive/unarchive loop-persistence feature (mitto-vmp) to the **un-loop button**, and makes **loop ⇄ un-loop a symmetric, non-destructive toggle** across every interface (REST **and** MCP).

Previously, pressing **Unloop** (`DELETE /api/sessions/{id}/loop`) hard-deleted `loop.json`, discarding the configuration. Now it **detaches**: `loop.json` is moved to `loop.saved.json` so the prompt / frequency / trigger / enabled state survive, and the conversation reverts to a regular one (`loop_configured=false`) exactly as before. Pressing **Make loop** restores the saved settings — preserving the enabled state they had at un-loop time (an active loop resumes; a paused draft comes back paused). Iteration/duration counters and the stopped reason are reset so the restored loop starts its budget fresh.

Closes **mitto-0do**.

## Changes

**Session layer** — `internal/session/loop.go`
- New `loop.saved.json` slot + `LoopStore.Detach` / `GetSaved` / `ClearSaved`.

**REST** — `internal/web/handlers`
- `handleDeleteLoop` now **detaches** instead of deleting (same `204` + `loop_updated(nil)` broadcast).
- New `POST /api/sessions/{id}/loop/restore` (`handleRestoreLoop`): restores the saved config, resets counters, clears the saved slot, re-broadcasts, bootstraps onCompletion; `404` when nothing is saved.
- `handleSetLoop` clears the saved slot after `Set` so a freshly-defined loop supersedes stale saved settings.

**MCP** — `internal/mcpserver/server.go`
- On create-loop (`isNew`) via `mitto_conversation_update`, clear the saved slot after `Set` — parity with the REST make-loop path.

**Frontend** — `web/static`
- `handleMakeLoop` tries `POST /loop/restore` first, falling back to a blank draft `PUT` on `404`; un-loop toast notes settings are saved for later restore.
- Added `endpoints.sessions.loopRestore`.

## Design notes

- **Symmetric enabled state**: re-loop restores the exact enabled state (active vs. paused) the loop had when detached — like archive ⇄ unarchive.
- **`loop_enabled:false` via MCP stays "pause"** (keeps `loop.json` via `MarkStopped`); it is intentionally **not** a full un-loop. The consistency fix therefore lives on the create-loop side (clear stale saved slot), not on disable.
- **Clear is explicit, not inside `Set()`**: the restore handler calls `Set(saved)` then `ClearSaved()`; keeping the lifecycle explicit matches the existing `Detach`/`GetSaved`/`ClearSaved` style.

## Testing

- **Session**: `Detach`/`GetSaved`/`ClearSaved` round-trips, not-found paths, overwrite-latest.
- **REST**: full un-loop → restore round-trip (prompt + enabled state preserved, counters reset, saved slot cleared), restore-404, set-clears-saved-slot.
- **MCP**: create-loop clears the saved slot.

### Gate results
`gofmt` clean · `go build ./...` ok · `go vet` clean · `go test ./internal/session ./internal/web/handlers ./internal/mcpserver` pass · `node --check` on `app.js` + `endpoints.js` ok.
